### PR TITLE
created NUnit project

### DIFF
--- a/src/Orient/Orient.Console/Orient.Console.csproj
+++ b/src/Orient/Orient.Console/Orient.Console.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Orient.Client\Orient.Client.csproj">
-      <Project>{224db9ba-3ba5-4955-b147-e540e1f270da}</Project>
+      <Project>{224DB9BA-3BA5-4955-B147-E540E1F270DA}</Project>
       <Name>Orient.Client</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/Orient/Orient.NUnit/AssemblySetup.cs
+++ b/src/Orient/Orient.NUnit/AssemblySetup.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.IO;
+using NUnit.Framework;
+
+namespace Orient.Tests
+{
+    [TestFixture]
+    public class AssemblySetup
+    {
+        [TestFixtureSetUp()]
+        public static void Setup(TestContext context)
+        {
+            // orientDbDir needs to point to the path of an OrientDB installation (pointing to the folder that contains the bin, lib, config sub folders)
+            var orientDBDir = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\..\orient.server"));
+            // jreDir needs to point to a JRE (or JDK)
+            var jreDir = @"C:\Program Files\Java\jre7";
+            DbRunner.StartOrientDb(orientDBDir, jreDir);
+        }
+
+        [TestFixtureTearDown()]
+        public static void TearDown()
+        {
+            DbRunner.StopOrientDb();
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/ClusterEqutableTest.cs
+++ b/src/Orient/Orient.NUnit/ClusterEqutableTest.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests
+{
+    [TestFixture]
+    public class ClusterEqutableTest
+    {
+        [Test]
+        public void ShoulBeEqualsClusters()
+        {
+            OCluster cluster1 = new OCluster { Id = 11, Name = "TestCluster", Type = OClusterType.Memory };
+            OCluster cluster2 = new OCluster { Id = 11, Name = "TestCluster", Type = OClusterType.Memory };
+            Assert.AreEqual(cluster1, cluster2);
+            Assert.IsTrue(cluster1 == cluster2);
+        }
+
+        [Test]
+        public void ShoulNotBeEqualsClusters()
+        {
+            OCluster cluster1 = new OCluster { Id = 11, Name = "TestCluster" };
+            OCluster cluster2 = new OCluster { Id = 11, Name = "TestCluster", Type = OClusterType.Memory };
+            Assert.AreNotEqual(cluster1, cluster2);
+            Assert.IsFalse(cluster1 == cluster2);
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Database/DataClusterTest.cs
+++ b/src/Orient/Orient.NUnit/Database/DataClusterTest.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Database
+{
+    [TestFixture]
+    public class DataClusterTest
+    {
+        [Test]
+        public void ShouldRetrieveNumberRecordsInSingleCluster()
+        {
+            using (var context = new TestDatabaseContext())
+            using (var database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                database.Create.Class("TestDocumentClass").Run();
+
+                for (int i = 0; i < 100; i++)
+                {
+                    database
+                        .Create
+                        .Document("TestDocumentClass")
+                        .Set("bar", i)
+                        .Run();
+                }
+
+                long recordsInCluster = database
+                    .Clusters("TestDocumentClass")
+                    .Count();
+
+                Assert.AreEqual(100, recordsInCluster);
+            }
+        }
+
+        [Test]
+        public void ShouldRetrieveDataRangeForSingle()
+        {
+            using (var context = new TestDatabaseContext())
+            using (var database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                var document = database.Clusters("OUser").Range();
+                Assert.IsNotNull(document);
+                Assert.AreEqual(1, document.Count);
+                Assert.IsTrue(document.ContainsKey("OUser"));
+                
+                var document1 = database.Clusters(4).Range();
+                Assert.IsNotNull(document1);
+                Assert.AreEqual(1, document1.Count);
+                Assert.IsTrue(document1.ContainsKey("4"));
+            }
+        }
+
+        [Test]
+        public void ShouldRetrieveDataRangeForMany()
+        {
+            using (var context = new TestDatabaseContext())
+            using (var database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                var document = database.Clusters("OUser","ORole","V").Range();
+                Assert.IsNotNull(document);
+                Assert.AreEqual(3, document.Count);
+                Assert.IsTrue(document.ContainsKey("OUser"));
+                Assert.IsTrue(document.ContainsKey("ORole"));
+                Assert.IsTrue(document.ContainsKey("V"));
+                
+                var document1 = database.Clusters(4, 5, 9).Range();
+                Assert.IsNotNull(document1);
+                Assert.AreEqual(3, document1.Count);
+                Assert.IsTrue(document1.ContainsKey("4"));
+                Assert.IsTrue(document1.ContainsKey("5"));
+                Assert.IsTrue(document1.ContainsKey("9"));
+
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Database/TestDatabaseOperations.cs
+++ b/src/Orient/Orient.NUnit/Database/TestDatabaseOperations.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Database
+{
+    [TestFixture]
+    public class TestDatabaseOperations
+    {
+        [Test]
+        public void ShouldReturnDatabaseSize()
+        {
+            using (var context = new TestDatabaseContext())
+            using (var database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                var size = database.Size;
+                Assert.IsTrue(size > 0);
+            }
+        }
+
+        [Test]
+        public void ShouldRetrieveCountRecords()
+        {
+            using (var context = new TestDatabaseContext())
+            using (var database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                var startRecords = database.CountRecords;
+                database
+                    .Create
+                    .Vertex("V")
+                    .Set("bar",1)
+                    .Run();
+
+                var endRecords = database.CountRecords;
+                Assert.AreEqual(startRecords + 1,endRecords);
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/DbRunner.cs
+++ b/src/Orient/Orient.NUnit/DbRunner.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+
+namespace Orient.Tests
+{
+    public class DbRunner
+    {
+        public static void StartOrientDb(string dbDir, string javaDir)
+        {
+        }
+
+        public static void StopOrientDb()
+        {
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Graph/GraphClassesTests.cs
+++ b/src/Orient/Orient.NUnit/Graph/GraphClassesTests.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Graph
+{
+    [TestFixture]
+    public class GraphClassesTests
+    {
+        [Test]
+        public void ShouldNotThrowExceptionWhenCreatingVerticesWithNonASCIIChars()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    //This commadn contains a character that will take up more than one byte
+                    OVertex vertex1 = database
+                        .Create.Vertex<OVertex>()
+                        .Set("Name", "René")
+                        .Run<OVertex>();
+                    //This command will throw exception if bytearray lengths and string lenghts are mixed up in protocol
+                    OVertex vertex2 = database.Create.Vertex<OVertex>().Set("Name", "test").Run<OVertex>();
+                }
+            }
+
+        }
+        [Test]
+        public void ShouldCreateVerticesWithEdge()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    OVertex vertex1 = database
+                        .Create.Vertex<OVertex>()
+                        .Set("Foo", "foo string value1")
+                        .Set("Bar", 12345)
+                        .Run<OVertex>();
+
+                    Assert.IsTrue(!string.IsNullOrEmpty(vertex1.ORID.ToString()));
+                    Assert.AreEqual("V", vertex1.OClassName);
+                    Assert.AreEqual("foo string value1", vertex1.GetField<string>("Foo"));
+                    Assert.AreEqual(12345, vertex1.GetField<int>("Bar"));
+
+                    OVertex vertex2 = database
+                        .Create.Vertex<OVertex>()
+                        .Set("Foo", "foo string value2")
+                        .Set("Bar", 54321)
+                        .Run<OVertex>();
+
+                    Assert.IsTrue(!string.IsNullOrEmpty(vertex2.ORID.ToString()));
+                    Assert.AreEqual("V", vertex2.OClassName);
+                    Assert.AreEqual("foo string value2", vertex2.GetField<string>("Foo"));
+                    Assert.AreEqual(54321, vertex2.GetField<int>("Bar"));
+
+                    OVertex vertex3 = database
+                        .Create.Vertex<OVertex>()
+                        .Set("Foo", "foo string value3")
+                        .Set("Bar", 347899)
+                        .Run<OVertex>();
+
+                    Assert.IsTrue(!string.IsNullOrEmpty(vertex3.ORID.ToString()));
+                    Assert.AreEqual("V", vertex3.OClassName);
+                    Assert.AreEqual("foo string value3", vertex3.GetField<string>("Foo"));
+                    Assert.AreEqual(347899, vertex3.GetField<int>("Bar"));
+
+                    OEdge edge1 = database
+                        .Create.Edge<OEdge>()
+                        .From(vertex1)
+                        .To(vertex2)
+                        .Set("Foo", "foo string value3")
+                        .Set("Bar", 123)
+                        .Run<OEdge>();
+
+                    Assert.IsTrue(!string.IsNullOrEmpty(edge1.ORID.ToString()));
+                    Assert.AreEqual("E", edge1.Label);
+                    Assert.AreEqual("E", edge1.OClassName);
+                    Assert.AreEqual(vertex2.ORID, edge1.InV);
+                    Assert.AreEqual(vertex1.ORID, edge1.OutV);
+                    Assert.AreEqual("foo string value3", edge1.GetField<string>("Foo"));
+                    Assert.AreEqual(123, edge1.GetField<int>("Bar"));
+
+                    OEdge edge2 = database
+                        .Create.Edge<OEdge>()
+                        .From(vertex1)
+                        .To(vertex3)
+                        .Set("Foo", "foo string value4")
+                        .Set("Bar", 245)
+                        .Run<OEdge>();
+
+                    Assert.IsTrue(!string.IsNullOrEmpty(edge2.ORID.ToString()));
+                    Assert.AreEqual("E", edge2.Label);
+                    Assert.AreEqual("E", edge2.OClassName);
+                    Assert.AreEqual(vertex3.ORID, edge2.InV);
+                    Assert.AreEqual(vertex1.ORID, edge2.OutV);
+                    Assert.AreEqual("foo string value4", edge2.GetField<string>("Foo"));
+                    Assert.AreEqual(245, edge2.GetField<int>("Bar"));
+
+                    OVertex loadedVertex1 = database
+                        .Select()
+                        .From(vertex1)
+                        .ToList<OVertex>().First();
+
+                    Assert.IsTrue(!string.IsNullOrEmpty(loadedVertex1.ORID.ToString()));
+                    Assert.AreEqual("V", loadedVertex1.OClassName);
+                    Assert.AreEqual(0, loadedVertex1.InE.Count);
+                    Assert.AreEqual(2, loadedVertex1.OutE.Count);
+                    Assert.IsTrue(loadedVertex1.OutE.Contains(edge1.ORID));
+                    Assert.IsTrue(loadedVertex1.OutE.Contains(edge2.ORID));
+                    Assert.AreEqual(vertex1.GetField<string>("Foo"), loadedVertex1.GetField<string>("Foo"));
+                    Assert.AreEqual(vertex1.GetField<int>("Bar"), loadedVertex1.GetField<int>("Bar"));
+
+                    OVertex loadedVertex2 = database
+                        .Select()
+                        .From(vertex2)
+                        .ToList<OVertex>().First();
+
+                    Assert.IsTrue(!string.IsNullOrEmpty(loadedVertex2.ORID.ToString()));
+                    Assert.AreEqual("V", loadedVertex2.OClassName);
+                    Assert.AreEqual(0, loadedVertex2.OutE.Count);
+                    Assert.AreEqual(1, loadedVertex2.InE.Count);
+                    Assert.IsTrue(loadedVertex2.InE.Contains(edge1.ORID));
+                    Assert.AreEqual(vertex2.GetField<string>("Foo"), loadedVertex2.GetField<string>("Foo"));
+                    Assert.AreEqual(vertex2.GetField<int>("Bar"), loadedVertex2.GetField<int>("Bar"));
+                }
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Graph/OrderedEdgesTest.cs
+++ b/src/Orient/Orient.NUnit/Graph/OrderedEdgesTest.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Graph
+{
+    [TestFixture]
+    public class OrderedEdgesTests
+    {
+        class Widget
+        {
+            public int Value { get; set; }
+            public List<ORID> out_VersionOf { get; set; }
+        }
+
+        class UnorderedWidget
+        {
+            public int Value { get; set; }
+            public HashSet<ORID> out_VersionOf { get; set; }
+        }
+
+        class WidgetVersion
+        {
+            public int Value { get; set; }
+            public HashSet<ORID> in_VersionOf { get; set; }
+
+        }
+
+        [Test]
+        public void TestUnOrderedEdges()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                database.Create.Class<UnorderedWidget>().Extends("V").CreateProperties().Run();
+                database.Create.Class<WidgetVersion>().Extends("V").CreateProperties().Run();
+
+                database.Create.Class("VersionOf").Extends("E").Run();
+
+                var w1 = new UnorderedWidget() { Value = 12 };
+                var wv1 = new WidgetVersion() { Value = 23 };
+                var wv2 = new WidgetVersion() { Value = 34 };
+
+                var v1 = database.Create.Vertex(w1).Run();
+                var v2 = database.Create.Vertex(wv1).Run();
+                var v3 = database.Create.Vertex(wv2).Run();
+
+                var e1 = database.Create.Edge("VersionOf").From(v1).To(v2).Run();
+                var e2 = database.Create.Edge("VersionOf").From(v1).To(v3).Run();
+
+                var loaded1 = database.Load.ORID(v1.ORID).Run<UnorderedWidget>();
+                Assert.AreEqual(2, loaded1.out_VersionOf.Count);
+                Assert.IsTrue(loaded1.out_VersionOf.Contains(e1.ORID));
+                Assert.IsTrue(loaded1.out_VersionOf.Contains(e1.ORID));
+                Assert.AreEqual(12, loaded1.Value);
+
+                var loaded2 = database.Load.ORID(v2.ORID).Run<WidgetVersion>();
+                Assert.IsNotNull(loaded2.in_VersionOf);
+                Assert.AreEqual(1, loaded2.in_VersionOf.Count);
+                Assert.AreEqual(23, loaded2.Value);
+                Assert.IsTrue(loaded2.in_VersionOf.Contains(e1.ORID));
+
+                var loaded3 = database.Load.ORID(v3.ORID).Run<WidgetVersion>();
+                Assert.IsNotNull(loaded3.in_VersionOf);
+                Assert.AreEqual(1, loaded3.in_VersionOf.Count);
+                Assert.AreEqual(34, loaded3.Value);
+                Assert.IsTrue(loaded3.in_VersionOf.Contains(e2.ORID));
+
+            }
+        }
+
+        [Test]
+        public void TestOrderedEdges()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                database.Create.Class<Widget>().Extends("V").CreateProperties().Run();
+                database.Create.Class<WidgetVersion>().Extends("V").CreateProperties().Run();
+
+                database.Create.Class("VersionOf").Extends("E").Run();
+
+                var w1 = new Widget() { Value = 12 };
+                var wv1 = new WidgetVersion() { Value = 23 };
+                var wv2 = new WidgetVersion() { Value = 34 };
+
+                var v1 = database.Create.Vertex(w1).Run();
+                var v2 = database.Create.Vertex(wv1).Run();
+                var v3 = database.Create.Vertex(wv2).Run();
+
+                var e1 = database.Create.Edge("VersionOf").From(v1).To(v2).Run();
+                var e2 = database.Create.Edge("VersionOf").From(v1).To(v3).Run();
+
+                var loaded1 = database.Load.ORID(v1.ORID).Run<Widget>();
+                Assert.AreEqual(2, loaded1.out_VersionOf.Count);
+                Assert.IsTrue(loaded1.out_VersionOf.Contains(e1.ORID));
+                Assert.IsTrue(loaded1.out_VersionOf.Contains(e2.ORID));
+                Assert.AreEqual(12, loaded1.Value);
+
+                var loaded2 = database.Load.ORID(v2.ORID).Run<WidgetVersion>();
+                Assert.IsNotNull(loaded2.in_VersionOf);
+                Assert.AreEqual(1, loaded2.in_VersionOf.Count);
+                Assert.AreEqual(23, loaded2.Value);
+                Assert.IsTrue(loaded2.in_VersionOf.Contains(e1.ORID));
+
+                var loaded3 = database.Load.ORID(v3.ORID).Run<WidgetVersion>();
+                Assert.IsNotNull(loaded3.in_VersionOf);
+                Assert.AreEqual(1, loaded3.in_VersionOf.Count);
+                Assert.AreEqual(34, loaded3.Value);
+                Assert.IsTrue(loaded3.in_VersionOf.Contains(e2.ORID));
+
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Issues/GitHub_issue2.cs
+++ b/src/Orient/Orient.NUnit/Issues/GitHub_issue2.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Issues
+{
+    [TestFixture]
+    public class GitHub_issue2
+    {
+        TestDatabaseContext _context;
+        ODatabase _database;
+
+        [SetUp]
+        public void Init()
+        {
+            _context = new TestDatabaseContext();
+            _database = new ODatabase(TestConnection.GlobalTestDatabaseAlias);
+
+            _database.Create.Class("TestVertex").Extends<OVertex>().Run();
+            _database.Create.Class("TestEdge").Extends<OEdge>().Run();
+
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            _database.Dispose();
+            _context.Dispose();
+        }
+
+        [Test]
+        public void CreateVertexWithHeavyEdgeTX()
+        {
+            var v1 = new ODocument { OClassName = "TestVertex" };
+            v1.SetField("Name", "First");
+            v1.SetField("Bar", 1);
+
+            var v2 = new ODocument { OClassName = "TestVertex" };
+            v2.SetField("Name", "Second");
+            v2.SetField("Bar", 2);
+
+            var e1 = new ODocument { OClassName = "TestEdge" };
+            e1.SetField("Weight", 1.3f);
+
+            // Add records to the transaction
+            _database.Transaction.Add(v1);
+            _database.Transaction.Add(v2);
+            _database.Transaction.Add(e1);
+
+            // link records
+            v1.SetField("in_TestEdge", e1.ORID);
+            v2.SetField("out_TestEdge", e1.ORID);
+            e1.SetField("in", v1.ORID);
+            e1.SetField("out", v2.ORID);
+
+            _database.Transaction.Commit();
+
+            Assert.IsNotNull(v1.ORID);
+            Assert.IsNotNull(v2.ORID);
+            Assert.IsNotNull(e1.ORID);
+
+            var lv1 = _database.Load.ORID(v1.ORID).Run();
+            var lv2 = _database.Load.ORID(v2.ORID).Run();
+            var le1 = _database.Load.ORID(e1.ORID).Run();
+
+            Assert.AreEqual(v1.GetField<string>("Name"), lv1.GetField<string>("Name"));
+            Assert.AreEqual(v1.GetField<int>("Bar"), lv1.GetField<int>("Bar"));
+
+            Assert.AreEqual(v2.GetField<string>("Name"), lv2.GetField<string>("Name"));
+            Assert.AreEqual(v2.GetField<int>("Bar"), lv2.GetField<int>("Bar"));
+
+            Assert.AreEqual(e1.GetField<float>("Weight"), le1.GetField<float>("Weight"));
+
+            Assert.AreEqual(e1.ORID, lv1.GetField<ORID>("in_TestEdge"));
+            Assert.AreEqual(e1.ORID, lv2.GetField<ORID>("out_TestEdge"));
+
+            Assert.AreEqual(v1.ORID, le1.GetField<ORID>("in"));
+            Assert.AreEqual(v2.ORID, le1.GetField<ORID>("out"));
+
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Issues/GitHub_issue4.cs
+++ b/src/Orient/Orient.NUnit/Issues/GitHub_issue4.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Issues
+{
+    [TestFixture]
+    public class GitHub_issue4
+    {
+        TestDatabaseContext _context;
+        ODatabase _database;
+
+        [SetUp]
+        public void Init()
+        {
+            _context = new TestDatabaseContext();
+            _database = new ODatabase(TestConnection.GlobalTestDatabaseAlias);
+            _database.Create.Class("TestVertex").Run();
+            _database.Create.Property("_datetime", OType.DateTime).Class("TestVertex").Run();
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            _database.Dispose();
+            _context.Dispose();
+        }
+
+        [Test]
+        [Ignore]
+        public void ShouldAxceptAllRangeOfDateTime()
+        {
+            var dtNow = DateTime.Now;
+            var dtUTCNow = DateTime.UtcNow;
+
+            // Gregorian calendar has hole between 1582-10-04 and 1582-10-15
+            // need adjust values
+
+            var dt15821015 = new DateTime(1582, 10, 15, 0, 0, 0, 0, DateTimeKind.Utc);
+            var dt15821014 = new DateTime(1582, 10, 14, 10, 0, 0, 0, DateTimeKind.Utc);
+            var dt15821004 = new DateTime(1582, 10, 4, 0, 0, 0, 0, DateTimeKind.Utc);
+            var dt15821003 = new DateTime(1582, 10, 3, 0, 0, 0, 0, DateTimeKind.Utc);            
+            var dt01000229 = new DateTime(0100, 2, 28, 0, 0, 0, 0, DateTimeKind.Utc);            
+            
+            var unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+
+            var doc0 = new ODocument { OClassName = "TestVertex" }
+                .SetField<DateTime>("_datetime", dt15821014);
+            
+            //var doc0 = new ODocument { OClassName = "TestVertex" }
+            //    .SetField<DateTime>("_datetime", dt15821015);
+
+            var doc1 = new ODocument { OClassName = "TestVertex" }
+                .SetField<DateTime>("_datetime", dt15821004);
+
+            var doc2 = new ODocument { OClassName = "TestVertex" }
+                .SetField<DateTime>("_datetime", dt15821003);
+
+            var doc3 = new ODocument { OClassName = "TestVertex" }
+                .SetField<DateTime>("_datetime", dt01000229);
+
+            var doc4 = new ODocument { OClassName = "TestVertex" }
+                .SetField<DateTime>("_datetime", default(DateTime));
+
+            var doc5 = new ODocument { OClassName = "TestVertex" }
+                .SetField<DateTime>("_datetime", new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+            var doc6 = new ODocument { OClassName = "TestVertex" }
+                .SetField<DateTime>("_datetime", dtNow);
+
+            var doc7 = new ODocument { OClassName = "TestVertex" }
+                .SetField<DateTime>("_datetime", dtUTCNow);
+
+            var doc8 = new ODocument { OClassName = "TestVertex" }
+                .SetField<DateTime>("_datetime", DateTime.MaxValue);
+
+            var insertedDoc0 = _database
+                .Insert(doc0)
+                .Run();
+
+            var insertedDoc1 = _database
+                .Insert(doc1)
+                .Run();
+
+            var insertedDoc2 = _database
+                .Insert(doc2)
+                .Run();
+
+            var insertedDoc3 = _database
+                .Insert(doc3)
+                .Run();
+
+            var insertedDoc4 = _database
+                .Insert(doc4)
+                .Run();
+
+            var insertedDoc5 = _database
+                .Insert(doc5)
+                .Run();
+
+            var insertedDoc6 = _database
+                .Insert(doc6)
+                .Run();
+
+            var insertedDoc7 = _database
+                .Insert(doc7)
+                .Run();
+
+            var insertedDoc8 = _database
+                .Insert(doc8)
+                .Run();
+
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Issues/GitHub_issue5.cs
+++ b/src/Orient/Orient.NUnit/Issues/GitHub_issue5.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Globalization;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Issues
+{
+    [TestFixture]
+    public class GitHub_issue5
+    {
+        TestDatabaseContext _context;
+        ODatabase _database;
+
+        [SetUp]
+        public void Init()
+        {
+            _context = new TestDatabaseContext();
+            _database = new ODatabase(TestConnection.GlobalTestDatabaseAlias);
+            _database.Create.Class("TestVertex").Extends<OVertex>().Run();
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            _database.Dispose();
+            _context.Dispose();
+        }
+
+
+        [Test]
+        public void TestGermanFloatCulture()
+        {
+            var floatValue = "108,4";
+
+            float @float;
+            float.TryParse(floatValue, NumberStyles.Any, CultureInfo.GetCultureInfo("de-DE"), out @float);
+
+            var doc = new ODocument { OClassName = "TestVertex" }
+                .SetField("floatField", @float);
+
+            var insertedDoc = _database.Insert(doc).Run();
+
+            Assert.IsNotNull(insertedDoc.ORID);
+            Assert.AreEqual(doc.GetField<float>("@float"), insertedDoc.GetField<float>("@float"));
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Issues/StackOverflow_q_26661636.cs
+++ b/src/Orient/Orient.NUnit/Issues/StackOverflow_q_26661636.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Issues
+{
+    // http://stackoverflow.com/questions/26661636/orientdb-net-binary-for-models
+    using q26661636;
+
+    [TestFixture]
+    public class StackOverflow_q_26661636
+    {
+        TestDatabaseContext _context;
+        ODatabase _database;
+
+        [SetUp]
+        public void Init()
+        {
+            _context = new TestDatabaseContext();
+            _database = new ODatabase(TestConnection.GlobalTestDatabaseAlias);
+
+            _database.Create.Class<Person>().Extends<OVertex>().CreateProperties().Run();
+            _database.Create.Class<Country>().Extends<OVertex>().CreateProperties().Run();
+            _database.Create.Class<Car>().Extends<OVertex>().CreateProperties().Run();
+            _database.Create.Class("Owns").Extends<OEdge>().Run();
+            _database.Create.Class("Lives").Extends<OEdge>().Run();
+
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            _database.Dispose();
+            _context.Dispose();
+        }
+
+        [Test]
+        [Category("Stackoverflow")]
+        public void q_26661636()
+        {
+            var lukaPerson = new Person { Name = "Luca" };
+            var lpV = _database.Create.Vertex(lukaPerson).Run();
+
+            var ferrariModenaCar = new Car { Name = "Ferrari Modena" };
+            var fmcV = _database.Create.Vertex(ferrariModenaCar).Run();
+            var bmwCar = new Car { Name = "BMW" };
+            var bmwcV = _database.Create.Vertex(bmwCar).Run();
+            var lp_fmcE = _database.Create.Edge("Owns").From(lpV.ORID).To(fmcV.ORID).Run();
+            var lp_bmwcE = _database.Create.Edge("Owns").From(lpV.ORID).To(bmwcV.ORID).Run();
+
+            var countryUS = new Country { Name = "US" };
+            var uscV = _database.Create.Vertex(countryUS).Run();
+            var lp_uscE = _database.Create.Edge("Lives").From(lpV.ORID).To(uscV.ORID).Run();
+
+            var countryUK = new Country { Name = "UK" };
+            var ukcV = _database.Create.Vertex(countryUK).Run();
+
+            var pl = _database.Select().From<Person>().ToList<Person>().FirstOrDefault(p => p.Name == lukaPerson.Name);
+
+            Assert.IsNotNull(pl);
+            Assert.AreEqual(lukaPerson.Name, pl.Name);
+            Assert.AreEqual(1, pl.out_Lives.Count);
+            Assert.AreEqual(2, pl.out_Owns.Count);
+        }
+    }
+
+    namespace q26661636
+    {
+        public class Person
+        {
+            public string Name { get; set; }
+            public List<ORID> out_Lives { get; set; }
+            public List<ORID> out_Owns { get; set; }
+        }
+
+        public class Country
+        {
+            public string Name { get; set; }
+            public List<ORID> in_Lives { get; set; }
+        }
+
+        public class Car
+        {
+            public string Name { get; set; }
+            public List<ORID> in_Owns { get; set; }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Issues/StackOverflow_q_26790891.cs
+++ b/src/Orient/Orient.NUnit/Issues/StackOverflow_q_26790891.cs
@@ -1,0 +1,471 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Orient.Client;
+using Orient.Client.API;
+using System.Reflection;
+using System.Collections;
+using System.Text.RegularExpressions;
+using Orient.Client.Mapping;
+using Orient.Client.Protocol.Serializers;
+
+
+namespace Orient.Tests.Issues
+{
+    // http://stackoverflow.com/questions/26790891/creating-edges-with-orientdb-net-binary-in-a-transaction
+
+    using q26790891;
+
+    [TestFixture]
+    public class StackOverflow_q_26790891
+    {
+        private IRecordSerializer serializer;
+        TestDatabaseContext context;
+        ODatabase database;
+
+        [SetUp]
+        public void Init()
+        {
+            context = new TestDatabaseContext();
+            database = new ODatabase(TestConnection.GlobalTestDatabaseAlias);
+            serializer = RecordSerializerFactory.GetSerializer(database);
+
+            // database.Create.Class<Person>().Extends<OVertex>().Run();
+            database.Create.Class<Person>().Extends<OVertex>().CreateProperties().Run();
+            database.Create.Class<Address>().Extends<OVertex>().CreateProperties().Run();
+            database.Create.Class<Dependent>().Extends<Person>().CreateProperties().Run();
+
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            context.Dispose();
+            context = null;
+            database.Dispose();
+            database = null;
+        }
+
+        [Test]
+        [Category("Stackoverflow")]
+        [Ignore]
+        public void q_26790891()
+        {
+            Person luca = new Person();
+            luca.Residence = new Address
+            {
+                AddressLine1 = "PO 2456",
+                AddressLine2 = "PO 1234"
+            };
+
+            database.Insert<Person>(luca, database.Transaction);
+        }
+    }
+
+
+    #region Supported classes
+
+    namespace q26790891
+    {
+        /// <summary>
+        /// Provides extension methods for <see cref="Orient.Client.ODatabase"/>
+        /// </summary>
+        public static class DatabaseExtensions
+        {
+            public static ORID ORID_DEFAULT = new ORID(-1, -1);
+
+            private const int SINGLE_RID_TARGET_PATTERN_INDEX = 3;
+            private static readonly string[] legalTargets = {
+                @"^(?:class:)?[a-zA-Z][a-zA-Z0-9]*$",       // Class
+                @"^cluster:\d+$",                           // Root cluster
+                @"^\[(?:#\d+:\d+\s*,?\s*)*(?:#\d+:\d+)\]$", // Array of RIDs
+                @"^#\d+:\d+$"                               // Single root record RID
+            };
+            private static readonly string[] reservedProperties = { 
+
+            };
+
+            /// <summary>
+            /// Fills out a collection of models of type <typeparamref name="T"/> using <c>traverse</c>. <paramref name="db"/> must be open.
+            /// </summary>
+            /// <remarks>
+            /// <para>Note that <c>traverse</c> can be slow, and <c>select</c> may be more appropriate. See
+            /// http://www.orientechnologies.com/docs/last/orientdb.wiki/SQL-Traverse.html#should-i-use-traverse-or-select
+            /// </para>
+            /// <para>Lightweight edges are not followed when populating model properties. Make sure to use "heavyweight" edges with either
+            /// <c>alter property MyEdgeClass.out MANDATORY=true</c> and <c>alter property MyEdgeClass.in MANDATORY=true</c>, or else
+            /// use <c>alter database custom useLightweightEdges=false</c>.</para>
+            /// </remarks>
+            /// <typeparam name="T">The model type. Must extend <see cref="OBaseRecord"/>, have a parameterless constructor, and most importantly it must be in the same
+            /// namespace as <see cref="OBaseRecord"/>.</typeparam>
+            /// <param name="db">The database to query</param>
+            /// <param name="from">A class, cluster, RID list, or RID to traverse. RIDs are in the form <c>#clusterId:clusterPosition</c>. Lists are in the form
+            /// <c>[RID,RID,...]</c> with one or more elements (whitespace is ignored). Clusters are in the form <c>cluster:clusterName</c> or <c>cluster:clusterId</c>.</param>
+            /// <exception cref="System.ArgumentException">If <paramref name="from"/> is an invalid format</exception>
+            /// <returns>An enumerable collection of models of type <typeparamref name="T"/>. Public instance properties of the models will have their values populated
+            /// based on all non-lightweight edges in the traversal.</returns>
+            public static IEnumerable<T> Traverse<T>(this ODatabase db, string from) where T : OBaseRecord, new()
+            {
+                // Sanity check on target
+                bool matches = false;
+                foreach (string pattern in legalTargets)
+                {
+                    if (Regex.IsMatch(from, pattern))
+                    {
+                        matches = true;
+                        break;
+                    }
+                }
+
+                if (!matches)
+                {
+                    throw new ArgumentException("Traverse target must be a class, cluster, RID list, or single RID.", "from");
+                }
+
+                bool fromSingleRecord = Regex.IsMatch(from, legalTargets[SINGLE_RID_TARGET_PATTERN_INDEX]);
+
+                // Traverse DB
+                string sql = string.Format("traverse * from {0}", from);
+                List<ODocument> result = db.Query(sql);
+                DatabaseTraversal traversal = new DatabaseTraversal(db, result);
+
+                // Process result
+                IEnumerable<T> models = traversal.ToModel<T>();
+                if (fromSingleRecord)
+                {
+                    // Either Traverse(ORID) was called, or client code called Traverse with an RID string -- return a single element
+                    models = models.Where(m => m.ORID.ToString().Equals(from));
+                }
+                return models;
+            }
+
+            /// <summary>
+            /// Fills out a model of type <typeparamref name="T"/> using <c>traverse</c>. <paramref name="db"/> must be open.
+            /// </summary>
+            /// <remarks>
+            /// <para>Note that <c>traverse</c> can be slow, and <c>select</c> may be more appropriate. See
+            /// http://www.orientechnologies.com/docs/last/orientdb.wiki/SQL-Traverse.html#should-i-use-traverse-or-select
+            /// </para>
+            /// <para>Lightweight edges are not followed when populating model properties. Make sure to use "heavyweight" edges with either
+            /// <c>alter property MyEdgeClass.out MANDATORY=true</c> and <c>alter property MyEdgeClass.in MANDATORY=true</c>, or else
+            /// use <c>alter database custom useLightweightEdges=false</c>.</para>
+            /// </remarks>
+            /// <typeparam name="T">The model type. Must extend <see cref="OBaseRecord"/>, have a parameterless constructor, and most importantly it must be in the same
+            /// namespace as <see cref="OBaseRecord"/>.</typeparam>
+            /// <param name="db">The database to query</param>
+            /// <param name="from">The root RID to traverse.</param>
+            /// <returns>A model representing the record indicated by <paramref name="from"/>.</returns>
+            public static T Traverse<T>(this ODatabase db, ORID from) where T : OBaseRecord, new()
+            {
+                // Traverse<T>(from.ToString()) is guaranteed to have 0 or 1 elements
+                return db.Traverse<T>(from.ToString()).SingleOrDefault();
+            }
+
+            public static void Insert<T>(this ODatabase db, T model,
+    OTransaction transaction) where T : OBaseRecord, new()
+            {
+                InsertHelper(db, model, transaction, new List<object>());
+            }
+
+            private static void InsertHelper<T>(ODatabase db, T model,
+                OTransaction transaction, ICollection<object> exclude, ORID parent = null)
+                    where T : OBaseRecord, new()
+            {
+                // Avoid following loops into a stack overflow
+                if (exclude.Contains(model)) return;
+                exclude.Add(model);
+
+                ODocument record = new ODocument();
+                record.OClassName = model.GetType().Name;
+                PropertyInfo[] properties = model.GetType().GetProperties(
+                    BindingFlags.Public | BindingFlags.Instance |
+                    BindingFlags.SetProperty | BindingFlags.GetProperty);
+                ICollection<PropertyInfo> linkableProperties = new List<PropertyInfo>();
+
+                foreach (PropertyInfo prop in properties)
+                {
+                    if (reservedProperties.Contains(prop.Name)) continue;
+
+                    OProperty aliasProperty = prop.GetCustomAttributes(typeof(OProperty))
+                        .Where(attr => ((OProperty)attr).Alias != null)
+                        .FirstOrDefault() as OProperty;
+                    string name = aliasProperty == null ? prop.Name : aliasProperty.Alias;
+
+                    // Record properties of model, but store properties linking to other
+                    // vertex classes for later
+                    if (typeof(OBaseRecord).IsAssignableFrom(prop.PropertyType))
+                    {
+                        linkableProperties.Add(prop);
+                    }
+                    else
+                    {
+                        record[name] = prop.GetValue(model);
+                    }
+                }
+
+                transaction.Add(record);
+                model.ORID = record.ORID;
+
+                foreach (PropertyInfo prop in linkableProperties)
+                {
+                    ORID outV, inV;
+                    OBaseRecord propValue = prop.GetValue(model) as OBaseRecord;
+                    if (!exclude.Select(ex => ex is OBaseRecord ? ((OBaseRecord)ex).ORID :
+                            ORID_DEFAULT).Contains(propValue.ORID))
+                    {
+                        MethodInfo insertMethod = typeof(DatabaseExtensions)
+                            .GetMethod("InsertHelper", BindingFlags.NonPublic |
+                                BindingFlags.Static).MakeGenericMethod(propValue.GetType());
+                        insertMethod.Invoke(null,
+                            new object[] {
+                    db, propValue, transaction, exclude, model.ORID
+                });
+                    }
+                    outV = model.ORID;
+                    inV = propValue.ORID;
+
+                    OEdgeAttribute edgeType =
+                        prop.GetCustomAttributes(typeof(OEdgeAttribute))
+                            .FirstOrDefault() as OEdgeAttribute;
+                    OProperty propertyAlias = prop.GetCustomAttributes(typeof(OProperty))
+                        .Where(p => ((OProperty)p).Alias != null)
+                        .FirstOrDefault() as OProperty;
+                    string alias = propertyAlias == null ? prop.Name : propertyAlias.Alias;
+                    if (edgeType != null)
+                    {
+                        OEdge link = new OEdge();
+                        link.OClassName = alias;
+                        link["out"] = outV;
+                        link["in"] = inV;
+                        if (edgeType.IsInV)
+                        {
+                            ORID tmp = link.OutV;
+                            link["out"] = link.InV;
+                            link["in"] = tmp;
+                        }
+
+                        // Do not create an edge if there is an edge already
+                        // connecting these vertices
+                        IEnumerable<Tuple<ORID, ORID>> excludedLinks = exclude
+                            .Select(ex => ex is OEdge ?
+                                new Tuple<ORID, ORID>(((OEdge)ex).OutV, ((OEdge)ex).InV) :
+                                new Tuple<ORID, ORID>(ORID_DEFAULT, ORID_DEFAULT));
+                        if (excludedLinks.Contains(
+                            new Tuple<ORID, ORID>(link.OutV, link.InV))) continue;
+
+                        exclude.Add(link);
+                        transaction.Add(link);
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Helper class for traversing <see cref="Orient.Client.ODatabase"/>
+            /// </summary>
+            private class DatabaseTraversal
+            {
+                private IEnumerable<ODocument> documents;
+                private IEnumerable<OEdge> edges;
+                private IDictionary<ORID, ODocument> documentMap;
+
+                private static readonly Func<Type, bool> isModelPropertyEnumerableHelper = pType => typeof(System.Collections.IEnumerable).IsAssignableFrom(pType);
+                private static readonly Func<PropertyInfo, string> isModelPropertyHelper = pInfo =>
+                {
+                    string alias = pInfo.Name;
+                    OProperty propertyAlias = pInfo.GetCustomAttributes(typeof(OProperty)).Where(attr => !string.IsNullOrEmpty(((OProperty)attr).Alias)).SingleOrDefault() as OProperty;
+                    if (propertyAlias != null)
+                    {
+                        alias = propertyAlias.Alias;
+                    }
+
+                    return alias;
+                };
+                private static readonly Action<dynamic, dynamic, string> setPropertiesHelper = (parent, child, className) =>
+                {
+                    PropertyInfo[] properties = parent.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.SetProperty | BindingFlags.GetProperty);
+                    PropertyInfo propertySingle = properties.Where(prop => IsModelProperty(prop, className)).SingleOrDefault();
+                    PropertyInfo propertyCollection = properties.Where(prop => IsModelCollectionProperty(prop, className)).SingleOrDefault();
+                    if (propertySingle != null)
+                    {
+                        propertySingle.SetValue(parent, child);
+                    }
+                    else if (propertyCollection != null)
+                    {
+                        dynamic propertyValue = propertyCollection.GetValue(parent);
+                        if (propertyValue == null)
+                        {
+                            Type listOfT = typeof(List<>).MakeGenericType(propertyCollection.PropertyType.GenericTypeArguments[0]);
+                            IEnumerable collection = (IEnumerable)Activator.CreateInstance(listOfT);
+                            propertyValue = collection;
+                            propertyCollection.SetValue(parent, collection);
+                        }
+
+                        propertyValue.Add(child);
+                    }
+                };
+
+                /// <summary>
+                /// Create new <see cref="DatabaseTraversal"/> object. <paramref name="database"/> must be open.
+                /// </summary>
+                /// <param name="database">Database to traverse. Required for discovering edges.</param>
+                /// <param name="documents">Documents produced by <c>traverse * from $target</c></param>
+                public DatabaseTraversal(ODatabase database, IEnumerable<ODocument> documents)
+                {
+                    this.documents = documents;
+                    documentMap = documents.ToDictionary<ODocument, ORID>(doc => doc.ORID);
+                    // Need to know which RIDs in documentMap are edges
+                    edges = database.Select().From("E").ToList<OEdge>().Where(edge => documentMap.ContainsKey(edge.ORID));
+                }
+
+                /// <summary>
+                /// Populate model object(s)
+                /// </summary>
+                /// <typeparam name="T">Type of model to return</typeparam>
+                /// <returns>A collection of model objects which appear in the traversal.</returns>
+                public IEnumerable<T> ToModel<T>() where T : OBaseRecord, new()
+                {
+                    if (documents.Count() == 0) return null;
+
+                    IDictionary<ORID, OBaseRecord> models = new Dictionary<ORID, OBaseRecord>();
+                    foreach (OEdge e in edges)
+                    {
+                        ODocument outDoc = documentMap[e.OutV];
+                        ODocument inDoc = documentMap[e.InV];
+
+                        dynamic outModel, inModel;
+                        bool containsOutId = models.ContainsKey(outDoc.ORID);
+                        bool containsInId = models.ContainsKey(inDoc.ORID);
+
+                        // Set the value for the models that edge is pointing into/out of
+                        if (containsOutId)
+                        {
+                            outModel = models[outDoc.ORID];
+                        }
+                        else
+                        {
+                            outModel = GetNewPropertyModel(typeof(T).Namespace, outDoc.OClassName);
+                            MapProperties(outDoc, outModel);
+                            models.Add(outModel.ORID, outModel);
+                        }
+
+                        if (containsInId)
+                        {
+                            inModel = models[inDoc.ORID];
+                        }
+                        else
+                        {
+                            inModel = GetNewPropertyModel(typeof(T).Namespace, inDoc.OClassName);
+                            MapProperties(inDoc, inModel);
+                            models.Add(inDoc.ORID, inModel);
+                        }
+
+                        // Set the property values for outModel to inModel if they exist
+                        setPropertiesHelper(outModel, inModel, e.OClassName);
+                        setPropertiesHelper(inModel, outModel, e.OClassName);
+                    }
+
+                    // Return models of type T
+                    IEnumerable<T> result = models.Select(kvp => kvp.Value).Where(model => model.OClassName.Equals(typeof(T).Name)).Cast<T>();
+                    return result;
+                }
+
+                /// <summary>
+                /// Map non-edge properties of the vertex to the model
+                /// </summary>
+                /// <typeparam name="T">The model type</typeparam>
+                /// <param name="document">The vertex</param>
+                /// <param name="resultObj">The model object</param>
+                private static void MapProperties<T>(ODocument document, T resultObj)
+                {
+                    (TypeMapperBase.GetInstanceFor(typeof(T)) as TypeMapper<T>).ToObject(document, resultObj);
+                }
+
+                /// <summary>
+                /// Create a new instance of a model type
+                /// </summary>
+                /// <param name="nSpace">The model's namespace</param>
+                /// <param name="modelName">The model's class name</param>
+                /// <returns>A newly-initialized instance of the class <c>nSpace.modelName</c></returns>
+                private static dynamic GetNewPropertyModel(string nSpace, string modelName)
+                {
+                    Type modelClass = Type.GetType(string.Format("{0}.{1}", nSpace, modelName));
+                    return modelClass.GetConstructor(Type.EmptyTypes).Invoke(null);
+                }
+
+                /// <summary>
+                /// Checks whether the given property or its alias is a vertex's class name and is not enumerable
+                /// </summary>
+                /// <param name="currentProperty">The property to compare name/alias against. Aliases should be set with <see cref="Orient.Client.OProperty"/></param>
+                /// <param name="name">The vertex class name to compare against</param>
+                /// <returns><see langword="true"/> if <paramref name="currentProperty"/> is named <paramref name="namne"/> or has an <see cref="Orient.Client.OProperty"/>
+                /// attribute with an alias of <paramref name="name"/>, and <paramref name="currentProperty"/> is not a collection type.</returns>
+                private static bool IsModelProperty(PropertyInfo currentProperty, string name)
+                {
+                    string alias = isModelPropertyHelper(currentProperty);
+                    return !isModelPropertyEnumerableHelper(currentProperty.PropertyType) && alias.Equals(name);
+                }
+
+                /// <summary>
+                /// Checks whether the given property or its alias is a vertex's class name and is enumerable
+                /// </summary>
+                /// <param name="currentProperty">The property to compare name/alias against. Aliases should be set with <see cref="Orient.Client.OProperty"/></param>
+                /// <param name="name">The vertex class name to compare against</param>
+                /// <returns><see langword="true"/> if <paramref name="currentProperty"/> is named <paramref name="namne"/> or has an <see cref="Orient.Client.OProperty"/>
+                /// attribute with an alias of <paramref name="name"/>, and <paramref name="currentProperty"/> is a collection type.</returns>
+                private static bool IsModelCollectionProperty(PropertyInfo currentProperty, string name)
+                {
+                    string alias = isModelPropertyHelper(currentProperty);
+                    return isModelPropertyEnumerableHelper(currentProperty.PropertyType) && alias.Equals(name);
+                }
+
+            }
+
+        }
+
+        [AttributeUsage(AttributeTargets.Property)]
+        public class OEdgeAttribute : Attribute
+        {
+            public bool IsInV { get; set; }
+            public bool IsOutV { get; set; }
+        }
+        public abstract class ABaseModel
+        {
+            public ORID ORID { get; set; }
+            public int OVersion { get; set; }
+            public ORecordType OType { get; set; }
+            public short OClassId { get; set; }
+            public string OClassName { get; set; }
+        }
+
+        public class Person : OBaseRecord
+        {
+            [OProperty(Alias = "ResidenceAddress")]
+            [OEdgeAttribute(IsOutV = true)]
+            public Address Residence { get; set; }
+
+            [OProperty(Alias = "ShippingAddress")]
+            [OEdgeAttribute(IsOutV = true)]
+            public Address Shipping { get; set; }
+        }
+
+        public class Dependent : Person
+        {
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+            // etc...
+        }
+
+        public class Address : OBaseRecord
+        {
+            public string AddressLine1 { get; set; }
+            public string AddressLine2 { get; set; }
+            // etc...
+
+            [OProperty(Alias = "PropertyAddress")]
+            public Person Resident { get; set; }
+        }
+    }
+
+    #endregion
+}

--- a/src/Orient/Orient.NUnit/Orient.NUnit.csproj
+++ b/src/Orient/Orient.NUnit/Orient.NUnit.csproj
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E9B69064-04DA-4554-A69F-A209106B525C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Orient.NUnit</RootNamespace>
+    <AssemblyName>Orient.NUnit</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="Orient.Tests.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblySetup.cs" />
+    <Compile Include="ClusterEqutableTest.cs" />
+    <Compile Include="DbRunner.cs" />
+    <Compile Include="TestConfigurationOperation.cs" />
+    <Compile Include="TestConnection.cs" />
+    <Compile Include="TestDatabaseContext.cs" />
+    <Compile Include="TestEdgeClass.cs" />
+    <Compile Include="TestProfileClass.cs" />
+    <Compile Include="TestVertexClass.cs" />
+    <Compile Include="Database\DataClusterTest.cs" />
+    <Compile Include="Database\TestDatabaseOperations.cs" />
+    <Compile Include="Graph\GraphClassesTests.cs" />
+    <Compile Include="Graph\OrderedEdgesTest.cs" />
+    <Compile Include="Issues\GitHub_issue2.cs" />
+    <Compile Include="Issues\GitHub_issue4.cs" />
+    <Compile Include="Issues\GitHub_issue5.cs" />
+    <Compile Include="Issues\StackOverflow_q_26661636.cs" />
+    <Compile Include="Issues\StackOverflow_q_26790891.cs" />
+    <Compile Include="Pool\ConnectionPoolTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Query\GremlinTests.cs" />
+    <Compile Include="Query\JavascriptTest.cs" />
+    <Compile Include="Query\LoadRecordTests.cs" />
+    <Compile Include="Query\SqlCreateClassTests.cs" />
+    <Compile Include="Query\SqlCreateClusterTests.cs" />
+    <Compile Include="Query\SqlCreateDocumentTests.cs" />
+    <Compile Include="Query\SqlCreateEdgeTests.cs" />
+    <Compile Include="Query\SqlCreatePropertyTest.cs" />
+    <Compile Include="Query\SqlCreateVertexTests.cs" />
+    <Compile Include="Query\SqlDeleteClusterTest.cs" />
+    <Compile Include="Query\SqlDeleteDocumentTests.cs" />
+    <Compile Include="Query\SqlDeleteEdgeTests.cs" />
+    <Compile Include="Query\SqlDeleteVertexTests.cs" />
+    <Compile Include="Query\SqlGenerateCreateClassQueryTests.cs" />
+    <Compile Include="Query\SqlGenerateCreateClusterQueryTests.cs" />
+    <Compile Include="Query\SqlGenerateCreateDocumentQueryTests.cs" />
+    <Compile Include="Query\SqlGenerateCreateEdgeQueryTests.cs" />
+    <Compile Include="Query\SqlGenerateCreateVertexQueryTests.cs" />
+    <Compile Include="Query\SqlGenerateDeleteDocumentQueryTests.cs" />
+    <Compile Include="Query\SqlGenerateDeleteEdgeQueryTests.cs" />
+    <Compile Include="Query\SqlGenerateDeleteVertexQueryTests.cs" />
+    <Compile Include="Query\SqlGenerateInsertQueryTests.cs" />
+    <Compile Include="Query\SqlGenerateSelectQueryTests.cs" />
+    <Compile Include="Query\SqlGenerateUpdateQueryTests.cs" />
+    <Compile Include="Query\SqlInsertTests.cs" />
+    <Compile Include="Query\SqlSelectTests.cs" />
+    <Compile Include="Query\SqlUpdateTests.cs" />
+    <Compile Include="Query\TestCreateVertex.cs" />
+    <Compile Include="Query\TestRecordMetadata.cs" />
+    <Compile Include="Query\TestTransactions.cs" />
+    <Compile Include="Query\UpdateRecordTest.cs" />
+    <Compile Include="Serialization\RecordBinaryDeserializationTest.cs" />
+    <Compile Include="Serialization\RecordBinarySerializationTest.cs" />
+    <Compile Include="Serialization\RecordDeserializationTests.cs" />
+    <Compile Include="Serialization\RecordDocumentSerializationTests.cs" />
+    <Compile Include="Serialization\RecordSerializationTests.cs" />
+    <Compile Include="Server\ServerOperationsTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Orient.Client\Orient.Client.csproj">
+      <Project>{224DB9BA-3BA5-4955-B147-E540E1F270DA}</Project>
+      <Name>Orient.Client</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ProjectExtensions>
+    <MonoDevelop>
+      <Properties>
+        <Policies>
+          <TextStylePolicy inheritsSet="VisualStudio" inheritsScope="text/plain" scope="text/x-csharp" />
+          <CSharpFormattingPolicy IndentSwitchBody="True" IndentBlocksInsideExpressions="True" AnonymousMethodBraceStyle="NextLine" PropertyBraceStyle="NextLine" PropertyGetBraceStyle="NextLine" PropertySetBraceStyle="NextLine" EventBraceStyle="NextLine" EventAddBraceStyle="NextLine" EventRemoveBraceStyle="NextLine" StatementBraceStyle="NextLine" ElseNewLinePlacement="NewLine" CatchNewLinePlacement="NewLine" FinallyNewLinePlacement="NewLine" WhileNewLinePlacement="DoNotCare" ArrayInitializerWrapping="DoNotChange" ArrayInitializerBraceStyle="NextLine" BeforeMethodDeclarationParentheses="False" BeforeMethodCallParentheses="False" BeforeConstructorDeclarationParentheses="False" NewLineBeforeConstructorInitializerColon="NewLine" NewLineAfterConstructorInitializerColon="SameLine" BeforeDelegateDeclarationParentheses="False" NewParentheses="False" SpacesBeforeBrackets="False" inheritsSet="Mono" inheritsScope="text/x-csharp" scope="text/x-csharp" />
+        </Policies>
+      </Properties>
+    </MonoDevelop>
+  </ProjectExtensions>
+</Project>

--- a/src/Orient/Orient.NUnit/Orient.Tests.csproj
+++ b/src/Orient/Orient.NUnit/Orient.Tests.csproj
@@ -1,0 +1,153 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{487B3635-ED01-4AD1-B90A-DA1E4358B580}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Orient.Tests</RootNamespace>
+    <AssemblyName>Orient.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System" />
+    <Reference Include="System.Management" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="AssemblySetup.cs" />
+    <Compile Include="Database\DataClusterTest.cs" />
+    <Compile Include="Database\TestDatabaseOperations.cs" />
+    <Compile Include="DbRunner.cs" />
+    <Compile Include="Graph\GraphClassesTests.cs" />
+    <Compile Include="Graph\OrderedEdgesTest.cs" />
+    <Compile Include="Issues\GitHub_issue2.cs" />
+    <Compile Include="Issues\StackOverflow_q_26661636.cs" />
+    <Compile Include="Issues\StackOverflow_q_26790891.cs" />
+    <Compile Include="Issues\GitHub_issue5.cs" />
+    <Compile Include="Query\LoadRecordTests.cs" />
+    <Compile Include="Query\SqlDeleteClusterTest.cs" />
+    <Compile Include="Query\SqlGenerateDeleteDocumentQueryTests.cs" />
+    <Compile Include="Query\SqlGenerateDeleteVertexQueryTests.cs" />
+    <Compile Include="Query\SqlGenerateDeleteEdgeQueryTests.cs" />
+    <Compile Include="Query\SqlCreateClassTests.cs" />
+    <Compile Include="Query\SqlCreateClusterTests.cs" />
+    <Compile Include="Query\SqlCreateDocumentTests.cs" />
+    <Compile Include="Query\SqlCreateVertexTests.cs" />
+    <Compile Include="Query\SqlCreateEdgeTests.cs" />
+    <Compile Include="Query\SqlDeleteDocumentTests.cs" />
+    <Compile Include="Query\SqlDeleteVertexTests.cs" />
+    <Compile Include="Query\SqlDeleteEdgeTests.cs" />
+    <Compile Include="Query\GremlinTests.cs" />
+    <Compile Include="Query\SqlCreatePropertyTest.cs" />
+    <Compile Include="Query\TestCreateVertex.cs" />
+    <Compile Include="Query\TestRecordMetadata.cs" />
+    <Compile Include="Query\UpdateRecordTest.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Serialization\RecordBinaryDeserializationTest.cs" />
+    <Compile Include="Serialization\RecordBinarySerializationTest.cs" />
+    <Compile Include="Query\JavascriptTest.cs" />
+    <Compile Include="TestProfileClass.cs" />
+    <Compile Include="Pool\ConnectionPoolTests.cs" />
+    <Compile Include="Query\SqlSelectTests.cs" />
+    <Compile Include="Query\SqlGenerateSelectQueryTests.cs" />
+    <Compile Include="Query\SqlGenerateUpdateQueryTests.cs" />
+    <Compile Include="Query\SqlUpdateTests.cs" />
+    <Compile Include="Query\SqlGenerateInsertQueryTests.cs" />
+    <Compile Include="Query\SqlInsertTests.cs" />
+    <Compile Include="Query\SqlGenerateCreateClassQueryTests.cs" />
+    <Compile Include="Query\SqlGenerateCreateClusterQueryTests.cs" />
+    <Compile Include="Query\SqlGenerateCreateVertexQueryTests.cs" />
+    <Compile Include="Query\SqlGenerateCreateEdgeQueryTests.cs" />
+    <Compile Include="Query\SqlGenerateCreateDocumentQueryTests.cs" />
+    <Compile Include="Serialization\RecordSerializationTests.cs" />
+    <Compile Include="Serialization\RecordDocumentSerializationTests.cs" />
+    <Compile Include="TestConnection.cs" />
+    <Compile Include="Serialization\RecordDeserializationTests.cs" />
+    <Compile Include="Server\ServerOperationsTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestDatabaseContext.cs" />
+    <Compile Include="TestEdgeClass.cs" />
+    <Compile Include="Query\TestTransactions.cs" />
+    <Compile Include="TestVertexClass.cs" />
+    <Compile Include="TestConfigurationOperation.cs" />
+    <Compile Include="ClusterEqutableTest.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Orient.Client\Orient.Client.csproj">
+      <Project>{224db9ba-3ba5-4955-b147-e540e1f270da}</Project>
+      <Name>Orient.Client</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup />
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Orient/Orient.NUnit/Pool/ConnectionPoolTests.cs
+++ b/src/Orient/Orient.NUnit/Pool/ConnectionPoolTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Pool
+{
+    [TestFixture]
+    public class ConnectionPoolTests
+    {
+        [Test]
+        public void ShouldRetrieveAndReturnDatabaseFromPool()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                Assert.AreEqual(
+                    TestConnection.GlobalTestDatabasePoolSize,
+                    OClient.DatabasePoolCurrentSize(TestConnection.GlobalTestDatabaseAlias)
+                );
+
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    Assert.AreEqual(
+                        TestConnection.GlobalTestDatabasePoolSize - 1,
+                        OClient.DatabasePoolCurrentSize(TestConnection.GlobalTestDatabaseAlias)
+                    );
+                }
+
+                Assert.AreEqual(
+                    TestConnection.GlobalTestDatabasePoolSize,
+                    OClient.DatabasePoolCurrentSize(TestConnection.GlobalTestDatabaseAlias)
+                );
+            }
+        }
+
+        [Test]
+        public void ShouldReturnDatabaseToPoolAfterCloseAndDisposeCall()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                Assert.AreEqual(
+                    TestConnection.GlobalTestDatabasePoolSize,
+                    OClient.DatabasePoolCurrentSize(TestConnection.GlobalTestDatabaseAlias)
+                );
+
+                ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias);
+
+                Assert.AreEqual(
+                    TestConnection.GlobalTestDatabasePoolSize - 1,
+                    OClient.DatabasePoolCurrentSize(TestConnection.GlobalTestDatabaseAlias)
+                );
+
+                database.Close();
+
+                Assert.AreEqual(
+                    TestConnection.GlobalTestDatabasePoolSize,
+                    OClient.DatabasePoolCurrentSize(TestConnection.GlobalTestDatabaseAlias)
+                );
+
+                database.Dispose();
+
+                Assert.AreEqual(
+                    TestConnection.GlobalTestDatabasePoolSize,
+                    OClient.DatabasePoolCurrentSize(TestConnection.GlobalTestDatabaseAlias)
+                );
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Properties/AssemblyInfo.cs
+++ b/src/Orient/Orient.NUnit/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Orient.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Orient.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("1c22155e-88e3-46e8-81af-141a3696f3a3")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Orient/Orient.NUnit/Query/GremlinTests.cs
+++ b/src/Orient/Orient.NUnit/Query/GremlinTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class GremlinTests
+    {
+        [Test]
+        [Category("Script")]
+        public void ShouldExecuteSimpleGremlinQuery()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    OVertex vertex1 = database
+                        .Create.Vertex<OVertex>()
+                        .Set("Foo", "foo string value 1")
+                        .Set("Bar", 12345)
+                        .Run();
+
+                    OVertex vertex2 = database
+                        .Create.Vertex<OVertex>()
+                        .Set("Foo", "foo string value 2")
+                        .Set("Bar", 54321)
+                        .Run();
+
+                    OEdge edge1 = database
+                        .Create.Edge<OEdge>()
+                        .From(vertex1)
+                        .To(vertex2)
+                        .Set("Foo", "foo string value 3")
+                        .Set("Bar", 123)
+                        .Run();
+
+                    List<ODocument> documents = database.Gremlin("g.V").ToList();
+                    Assert.AreEqual(2, documents.Count);
+                    var loadedVertex1 = documents.Find(d => d.ORID.Equals(vertex1.ORID));
+                    var loadedVertex2 = documents.Find(d => d.ORID.Equals(vertex2.ORID));
+                    Assert.IsNotNull(loadedVertex1);
+                    Assert.IsNotNull(loadedVertex2);
+
+                    Assert.AreEqual(vertex1.GetField<string>("Foo"), loadedVertex1.GetField<string>("Foo"));
+                    Assert.AreEqual(vertex1.GetField<int>("Bar"), loadedVertex1.GetField<int>("Bar"));
+                    Assert.AreEqual(vertex2.GetField<string>("Foo"), loadedVertex2.GetField<string>("Foo"));
+                    Assert.AreEqual(vertex2.GetField<int>("Bar"), loadedVertex2.GetField<int>("Bar"));
+
+                    Assert.AreEqual(1, loadedVertex1.GetField<HashSet<ORID>>("out_").Count);
+                    Assert.IsTrue(loadedVertex1.GetField<HashSet<ORID>>("out_").Contains(edge1.ORID));
+                    Assert.IsTrue(loadedVertex2.GetField<HashSet<ORID>>("in_").Contains(edge1.ORID));
+                }
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/JavascriptTest.cs
+++ b/src/Orient/Orient.NUnit/Query/JavascriptTest.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class JavascriptTest
+    {
+        [Test]
+        [Category("Script")]
+        public void ShouldExecuteSimpleJavascriptQuery()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                OVertex vertex1 = database
+                    .Create.Vertex<OVertex>()
+                    .Set("Foo", "foo string value 1")
+                    .Set("Bar", 12345)
+                    .Run();
+
+                OVertex vertex2 = database
+                    .Create.Vertex<OVertex>()
+                    .Set("Foo", "foo string value 2")
+                    .Set("Bar", 54321)
+                    .Run();
+
+                OEdge edge1 = database
+                    .Create.Edge<OEdge>()
+                    .From(vertex1)
+                    .To(vertex2)
+                    .Set("Foo", "foo string value 3")
+                    .Set("Bar", 123)
+                    .Run();
+
+                List<ODocument> documents = database
+                    .JavaScript("db.command('select from V');")
+                    .Run()
+                    .ToList();
+
+                Assert.AreEqual(2, documents.Count);
+                var loadedVertex1 = documents.Find(d => d.ORID.Equals(vertex1.ORID));
+                var loadedVertex2 = documents.Find(d => d.ORID.Equals(vertex2.ORID));
+                Assert.IsNotNull(loadedVertex1);
+                Assert.IsNotNull(loadedVertex2);
+
+                Assert.AreEqual(vertex1.GetField<string>("Foo"), loadedVertex1.GetField<string>("Foo"));
+                Assert.AreEqual(vertex1.GetField<int>("Bar"), loadedVertex1.GetField<int>("Bar"));
+                Assert.AreEqual(vertex2.GetField<string>("Foo"), loadedVertex2.GetField<string>("Foo"));
+                Assert.AreEqual(vertex2.GetField<int>("Bar"), loadedVertex2.GetField<int>("Bar"));
+
+                Assert.AreEqual(1, loadedVertex1.GetField<HashSet<ORID>>("out_").Count);
+                Assert.IsTrue(loadedVertex1.GetField<HashSet<ORID>>("out_").Contains(edge1.ORID));
+                Assert.IsTrue(loadedVertex2.GetField<HashSet<ORID>>("in_").Contains(edge1.ORID));
+            }
+        }
+
+        [Test]
+        [Category("Script")]
+        public void ShouldExecuteSimpleFunction()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                database
+                    .Command("create function sum 'return a+b' parameters [a , b] language javascript");
+                var result = database
+                    .JavaScript("sum(a,b);")
+                    .Set("a",3)
+                    .Set("b",5)
+                    .Run()
+                    .ToSingle();
+                
+                Assert.IsNotNull(result);
+                Assert.AreEqual(1, result.Count);
+                var actual = result.GetField<string>("value");
+                if (actual != "8") // 8 seems to come back from this call - maybe depends on exact version of OrientDB server?... Anyway, it's a good enough result
+                {
+                    Assert.AreEqual("8.0d", actual);
+                }
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/LoadRecordTests.cs
+++ b/src/Orient/Orient.NUnit/Query/LoadRecordTests.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class LoadRecordTests
+    {
+
+        [Test]
+        public void TestLoadNoFetchPlan()
+        {
+            using (var testContext = new TestDatabaseContext())
+            using (var database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                // prerequisites
+                database
+                    .Create.Class("TestClass")
+                    .Run();
+
+                ODocument document = new ODocument()
+                    .SetField("foo", "foo string value")
+                    .SetField("bar", 12345);
+
+                ODocument insertedDocument = database
+                    .Insert(document)
+                    .Into("TestClass")
+                    .Run();
+                var loaded = database.Load.ORID(insertedDocument.ORID).Run();
+                Assert.AreEqual("TestClass", loaded.OClassName);
+                Assert.AreEqual(document.GetField<string>("foo"), loaded.GetField<string>("foo"));
+                Assert.AreEqual(document.GetField<int>("bar"), loaded.GetField<int>("bar"));
+                Assert.AreEqual(insertedDocument.ORID, loaded.ORID);
+
+            }
+        }
+        [Test]
+        public void TestLoadRawDataRecordType()
+        {
+
+            using (var testContext = new TestDatabaseContext())
+            using (var database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                var config = database.Load.ORID(new ORID(0, 0)).Run();
+                Assert.IsInstanceOf<ODocument>(config);
+                Assert.IsTrue(config.GetField<byte[]>("RawBytes").Length > 0);
+            }
+
+        }
+        [Test]
+        public void TestLoadWithFetchPlanNoLinks()
+        {
+            using (var testContext = new TestDatabaseContext())
+            using (var database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                // prerequisites
+                database
+                    .Create.Class("TestClass")
+                    .Run();
+
+                ODocument document = new ODocument()
+                    .SetField("foo", "foo string value")
+                    .SetField("bar", 12345);
+
+                ODocument insertedDocument = database
+                    .Insert(document)
+                    .Into("TestClass")
+                    .Run();
+                var loaded = database.Load.ORID(insertedDocument.ORID).FetchPlan("*:1").Run();
+                Assert.AreEqual("TestClass", loaded.OClassName);
+                Assert.AreEqual(document.GetField<string>("foo"), loaded.GetField<string>("foo"));
+                Assert.AreEqual(document.GetField<int>("bar"), loaded.GetField<int>("bar"));
+                Assert.AreEqual(insertedDocument.ORID, loaded.ORID);
+
+            }
+        }
+
+        [Test]
+        public void TestLoadWithFetchPlanWithLinks()
+        {
+            using (var testContext = new TestDatabaseContext())
+            using (var database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                // prerequisites
+                database
+                    .Create.Class("TestClass")
+                    .Run();
+
+                ODocument document = new ODocument()
+                    .SetField("foo", "foo string value")
+                    .SetField("bar", 12345);
+
+                ODocument insertedDocument = database
+                    .Insert(document)
+                    .Into("TestClass")
+                    .Run();
+
+                for (int i = 0; i < 2; i++)
+                {
+
+                    ODocument document2 = new ODocument()
+                        .SetField("foo", "bar string value")
+                        .SetField("bar", 23456);
+
+                    ODocument insertedDocument2 = database
+                        .Insert(document2)
+                        .Into("TestClass")
+                        .Run();
+                    database.Create.Edge("E").From(insertedDocument).To(insertedDocument2).Run();
+                }
+
+
+                var loaded = database.Load.ORID(insertedDocument.ORID).FetchPlan("*:1").Run();
+                Assert.AreEqual("TestClass", loaded.OClassName);
+                Assert.AreEqual(document.GetField<string>("foo"), loaded.GetField<string>("foo"));
+                Assert.AreEqual(document.GetField<int>("bar"), loaded.GetField<int>("bar"));
+                Assert.AreEqual(insertedDocument.ORID, loaded.ORID);
+
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlCreateClassTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlCreateClassTests.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+using System.Linq;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlCreateClassTests
+    {
+        [Test]
+        public void ShouldCreateClass()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    short classId1 = database
+                        .Create.Class("TestClass1")
+                        .Run();
+
+                    Assert.IsTrue(classId1 > 0);
+
+                    short classId2 = database
+                        .Create.Class("TestClass2")
+                        .Run();
+
+                    Assert.IsTrue(classId2 > 0);
+
+                    Assert.AreEqual(classId1 + 1, classId2);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldCreateClassExtends()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    short classId1 = database
+                        .Create.Class("TestClass1")
+                        .Extends("OVertex")
+                        .Run();
+
+                    Assert.IsTrue(classId1 > 0);
+
+                    short classId2 = database
+                        .Create.Class("TestClass2")
+                        .Extends<OVertex>()
+                        .Run();
+
+                    Assert.IsTrue(classId2 > 0);
+
+                    Assert.AreEqual(classId1 + 1, classId2);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldCreateClassCluster()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    short clusterid1 = database
+                        .Create
+                        .Cluster("ClasterForTest1", OClusterType.None)
+                        .Run();
+
+                    short clusterid2 = database
+                        .Create
+                        .Cluster("ClasterForTest2", OClusterType.None)
+                        .Run();
+
+                    short classId1 = database
+                        .Create.Class("TestClass1")
+                        .Cluster(clusterid1)
+                        .Run();
+
+                    Assert.IsTrue(classId1 > 0);
+
+                    short classId2 = database
+                        .Create.Class("TestClass2")
+                        .Cluster(clusterid2)
+                        .Run();
+
+                    Assert.AreEqual(classId1 + 1, classId2);
+                }
+            }
+        }
+
+        class TestClass
+        {
+            public int Value { get; set; }
+            public string Text { get; set; }
+            public bool Flag { get; set; }
+            public long LongValue { get; set; }
+            public short ShortValue { get; set; }
+            public byte Byte { get; set; }
+            public byte[] data { get; set; }
+        }
+
+        [Test]
+        public void ShouldCreateClassWithProperties()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    short classId1 = database.Create.Class<TestClass>().CreateProperties().Run();
+
+                    Assert.IsTrue(classId1 > 0);
+
+                    // would like to test the properties have been created properly, but the server doesn't implement 'info' over the remove protocol
+                    //var result = database.Command("info class TestClass");
+                    
+                    var schema = database.Schema.Properties<TestClass>();
+                }
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlCreateClusterTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlCreateClusterTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlCreateClusterTests
+    {
+        [Test]
+        public void ShouldCreateCluster()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    short clusterId1 = database
+                        .Create.Cluster("TestCluster1", OClusterType.Physical)
+                        .Run();
+
+                    Assert.IsTrue(clusterId1 > 0);
+
+                    short clusterId2 = database
+                        .Create.Cluster<TestProfileClass>(OClusterType.Physical)
+                        .Run();
+
+                    Assert.AreEqual(clusterId1 + 1, clusterId2);
+                }
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlCreateDocumentTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlCreateDocumentTests.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlCreateDocumentTests
+    {
+        [Test]
+        public void ShouldCreateDocumentFromDocument()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    ODocument document = new ODocument();
+                    document.OClassName = "TestClass";
+                    document
+                        .SetField("foo", "foo string value")
+                        .SetField("bar", 12345);
+
+                    ODocument createdDocument = database
+                        .Create.Document(document)
+                        .Run();
+
+                    Assert.IsNotNull(createdDocument.ORID);
+                    Assert.AreEqual("TestClass", createdDocument.OClassName);
+                    Assert.AreEqual(document.GetField<string>("foo"), createdDocument.GetField<string>("foo"));
+                    Assert.AreEqual(document.GetField<int>("bar"), createdDocument.GetField<int>("bar"));
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldCreateDocumentFromObject()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class<TestProfileClass>()
+                        .Run();
+
+                    TestProfileClass profile = new TestProfileClass();
+                    profile.Name = "Johny";
+                    profile.Surname = "Bravo";
+
+                    TestProfileClass createdObject = database
+                        .Create.Document(profile)
+                        .Run<TestProfileClass>();
+
+                    Assert.IsNotNull(createdObject.ORID);
+                    Assert.AreEqual(typeof(TestProfileClass).Name, createdObject.OClassName);
+                    Assert.AreEqual(profile.Name, createdObject.Name);
+                    Assert.AreEqual(profile.Surname, createdObject.Surname);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldCreateDocumentClassSet()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    ODocument document = new ODocument();
+                    document.OClassName = "TestClass";
+                    document
+                        .SetField("foo", "foo string value")
+                        .SetField("bar", 12345);
+
+                    ODocument createdDocument = database
+                        .Create.Document("TestClass")
+                        .Set(document)
+                        .Run();
+
+                    Assert.IsNotNull(createdDocument.ORID);
+                    Assert.AreEqual("TestClass", createdDocument.OClassName);
+                    Assert.AreEqual(document.GetField<string>("foo"), createdDocument.GetField<string>("foo"));
+                    Assert.AreEqual(document.GetField<int>("bar"), createdDocument.GetField<int>("bar"));
+                }
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlCreateEdgeTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlCreateEdgeTests.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlCreateEdgeTests
+    {
+        [Test]
+        public void ShouldCreateEdgeClusterFromTo()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestEdgeClass")
+                        .Extends<OEdge>()
+                        .Run();
+
+                    database
+                        .Create.Cluster("TestCluster", OClusterType.Physical)
+                        .Run();
+                    
+                    var res = database.Command("alter class TestEdgeClass addcluster testcluster");
+
+                    OVertex vertex1 = database
+                        .Create.Vertex<OVertex>()
+                        .Run();
+
+                    OVertex vertex2 = database
+                        .Create.Vertex<OVertex>()
+                        .Run();
+
+                    OEdge createdEdge = database
+                        .Create.Edge("TestEdgeClass")
+                        .Cluster("TestCluster")
+                        .From(vertex1.ORID)
+                        .To(vertex2.ORID)
+                        .Run();
+
+                    Assert.IsNotNull(createdEdge.ORID);
+                    Assert.AreEqual("TestEdgeClass", createdEdge.Label);
+                    Assert.AreEqual("TestEdgeClass", createdEdge.OClassName);
+                    Assert.AreEqual(vertex2.ORID, createdEdge.InV);
+                    Assert.AreEqual(vertex1.ORID, createdEdge.OutV);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldCreateEdgeFromOEdge()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    OVertex vertex1 = database
+                        .Create.Vertex<OVertex>()
+                        .Run();
+
+                    OVertex vertex2 = database
+                        .Create.Vertex<OVertex>()
+                        .Run();
+
+                    OEdge edge = new OEdge();
+                    edge.SetField("Foo", "foo string value");
+                    edge.SetField("Bar", 12345);
+
+                    OEdge createdEdge = database
+                        .Create.Edge(edge)
+                        .From(vertex1)
+                        .To(vertex2)
+                        .Run();
+
+                    Assert.IsNotNull(createdEdge.ORID);
+                    Assert.AreEqual("E", createdEdge.Label);
+                    Assert.AreEqual("E", createdEdge.OClassName);
+                    Assert.AreEqual(vertex2.ORID, createdEdge.InV);
+                    Assert.AreEqual(vertex1.ORID, createdEdge.OutV);
+                    Assert.AreEqual(edge.GetField<string>("Foo"), createdEdge.GetField<string>("Foo"));
+                    Assert.AreEqual(edge.GetField<int>("Bar"), createdEdge.GetField<int>("Bar"));
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldCreateEdgeFromToSet()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestEdgeClass")
+                        .Extends<OEdge>()
+                        .Run();
+
+                    OVertex vertex1 = database
+                        .Create.Vertex<OVertex>()
+                        .Run();
+
+                    OVertex vertex2 = database
+                        .Create.Vertex<OVertex>()
+                        .Run();
+
+                    OEdge createdEdge = database
+                        .Create.Edge("TestEdgeClass")
+                        .From(vertex1.ORID)
+                        .To(vertex2.ORID)
+                        .Set("foo", "foo string value")
+                        .Set("bar", 12345)
+                        .Run();
+
+                    Assert.IsNotNull(createdEdge.ORID);
+                    Assert.AreEqual("TestEdgeClass", createdEdge.Label);
+                    Assert.AreEqual("TestEdgeClass", createdEdge.OClassName);
+                    Assert.AreEqual(vertex2.ORID, createdEdge.InV);
+                    Assert.AreEqual(vertex1.ORID, createdEdge.OutV);
+                    Assert.AreEqual("foo string value", createdEdge.GetField<string>("foo"));
+                    Assert.AreEqual(12345, createdEdge.GetField<int>("bar"));
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldCreateEdgeObjectFromDocumentToDocument()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class<TestProfileClass>()
+                        .Extends<OEdge>()
+                        .Run();
+
+                    OVertex vertex1 = database
+                        .Create.Vertex<OVertex>()
+                        .Run();
+
+                    OVertex vertex2 = database
+                        .Create.Vertex<OVertex>()
+                        .Run();
+
+                    TestProfileClass profile = new TestProfileClass();
+                    profile.Name = "Johny";
+                    profile.Surname = "Bravo";
+
+                    TestProfileClass createdEdge = database
+                        .Create.Edge(profile)
+                        .From(vertex1)
+                        .To(vertex2)
+                        .Run<TestProfileClass>();
+
+                    Assert.IsNotNull(createdEdge.ORID);
+                    Assert.AreEqual(profile.Name, createdEdge.Name);
+                    Assert.AreEqual(profile.Surname, createdEdge.Surname);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldCreateEdgeObjectFromObjectToObject()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class<TestProfileClass>()
+                        .Extends<OEdge>()
+                        .Run();
+
+                    OVertex vertex1 = database
+                        .Create.Vertex<OVertex>()
+                        .Run<OVertex>();
+
+                    OVertex vertex2 = database
+                        .Create.Vertex<OVertex>()
+                        .Run<OVertex>();
+
+                    TestProfileClass profile = new TestProfileClass();
+                    profile.Name = "Johny";
+                    profile.Surname = "Bravo";
+
+                    TestProfileClass createdEdge = database
+                        .Create.Edge(profile)
+                        .From(vertex1)
+                        .To(vertex2)
+                        .Run<TestProfileClass>();
+
+                    Assert.IsNotNull(createdEdge.ORID);
+                    Assert.AreEqual(profile.Name, createdEdge.Name);
+                    Assert.AreEqual(profile.Surname, createdEdge.Surname);
+                }
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlCreatePropertyTest.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlCreatePropertyTest.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlCreatePropertyTest
+    {
+        private string _metadataQuery = "select expand(properties) from (select expand(classes) from #0:1) where name='TestClass'";
+
+        [Test]
+        public void ShouldCreateProperty()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Extends<OVertex>()
+                        .Run();
+
+
+                    // Basic Test
+                    foreach (var item in Enum.GetNames(typeof(OType)))
+                    {
+                        database.Create
+                            .Property("_" + item.ToLower(), (OType)Enum.Parse(typeof(OType), item))
+                            .Class("TestClass")
+                            .Run();
+                    }
+
+                    var document = database.Query(_metadataQuery);
+
+                    foreach (var item in Enum.GetNames(typeof(OType)))
+                    {
+                        var metadata = document.Find(d => d.GetField<string>("name") == "_" + item.ToLower());
+                        validateMetadata(metadata, (OType)Enum.Parse(typeof(OType), item));
+                    }
+
+                    // Complex Test
+                    database
+                        .Create
+                        .Property("_embededlist_with_type", OType.EmbeddedList)
+                        .LinkedType(OType.Integer)
+                        .Class("TestClass")
+                        .Run();
+
+                    database
+                        .Create
+                        .Property("_embededlist_with_class", OType.EmbeddedList)
+                        .LinkedClass("OUser")
+                        .Class("TestClass")
+                        .Run();
+
+                    document = database.Query(_metadataQuery);
+
+                    var elwtMetadata = document.Find(d => d.GetField<string>("name") == "_embededlist_with_type");
+                    validateMetadata(elwtMetadata, OType.EmbeddedList);
+                    Assert.AreEqual(OType.Integer, (OType)elwtMetadata.GetField<int>("linkedType"));
+
+                    var elwcMetadata = document.Find(d => d.GetField<string>("name") == "_embededlist_with_class");
+                    validateMetadata(elwtMetadata, OType.EmbeddedList);
+                    Assert.AreEqual("OUser", elwcMetadata.GetField<string>("linkedClass"));
+
+                }
+            }
+        }
+
+        private void validateMetadata(ODocument metadata, OType expectedType)
+        {
+            Assert.IsNotNull(metadata);
+            Assert.AreEqual(expectedType, (OType)metadata.GetField<int>("type"));
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlCreateVertexTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlCreateVertexTests.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlCreateVertexTests
+    {
+        [Test]
+        public void ShouldCreateVertexSet()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestVertexClass")
+                        .Extends<OVertex>()
+                        .Run();
+
+                    OVertex createdVertex = database
+                        .Create.Vertex("TestVertexClass")
+                        .Set("foo", "foo string value")
+                        .Set("bar", 12345)
+                        .Run();
+
+                    Assert.IsNotNull(createdVertex.ORID);
+                    Assert.AreEqual("TestVertexClass", createdVertex.OClassName);
+                    Assert.AreEqual("foo string value", createdVertex.GetField<string>("foo"));
+                    Assert.AreEqual(12345, createdVertex.GetField<int>("bar"));
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldCreateVertexFromDocument()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestVertexClass")
+                        .Extends<OVertex>()
+                        .Run();
+
+                    ODocument document = new ODocument();
+                    document.OClassName = "TestVertexClass";
+                    document
+                        .SetField("foo", "foo string value")
+                        .SetField("bar", 12345);
+
+                    OVertex createdVertex = database
+                        .Create.Vertex(document)
+                        .Run();
+
+                    Assert.IsNotNull(createdVertex.ORID);
+                    Assert.AreEqual("TestVertexClass", createdVertex.OClassName);
+                    Assert.AreEqual(document.GetField<string>("foo"), createdVertex.GetField<string>("foo"));
+                    Assert.AreEqual(document.GetField<int>("bar"), createdVertex.GetField<int>("bar"));
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldCreateVertexFromOVertex()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    OVertex vertex = new OVertex();
+                    vertex
+                        .SetField("foo", "foo string value")
+                        .SetField("bar", 12345);
+
+                    OVertex createdVertex = database
+                        .Create.Vertex(vertex)
+                        .Run();
+
+                    Assert.IsNotNull(createdVertex.ORID);
+                    Assert.AreEqual("V", createdVertex.OClassName);
+                    Assert.AreEqual(vertex.GetField<string>("foo"), createdVertex.GetField<string>("foo"));
+                    Assert.AreEqual(vertex.GetField<int>("bar"), createdVertex.GetField<int>("bar"));
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldCreateVertexFromObject()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class<TestProfileClass>()
+                        .Extends<OVertex>()
+                        .Run();
+
+                    TestProfileClass profile = new TestProfileClass();
+                    profile.Name = "Johny";
+                    profile.Surname = "Bravo";
+
+                    TestProfileClass createdVertex = database
+                        .Create.Vertex(profile)
+                        .Run<TestProfileClass>();
+
+                    Assert.IsNotNull(createdVertex.ORID);
+                    Assert.AreEqual(typeof(TestProfileClass).Name, createdVertex.OClassName);
+                    Assert.AreEqual(profile.Name, createdVertex.Name);
+                    Assert.AreEqual(profile.Surname, createdVertex.Surname);
+                }
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlDeleteClusterTest.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlDeleteClusterTest.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlDeleteClusterTest
+    {
+        [Test]
+        public void ShouldDeleteCluster()
+        {
+            using (var context = new TestDatabaseContext())
+            using (var database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                var clusterid = database.Create.Cluster("TestClaster", OClusterType.Memory).Run();
+                var clusters = database.GetClusters();
+                var clusterLength = clusters.Count;
+
+                Assert.IsTrue(clusterid > 0);
+                Assert.IsTrue(clusters.Any(c => c.Id == clusterid));
+
+                database.Delete.Cluster(clusterid).Run();
+//                Assert.AreEqual(clusterLength - 1, clusters.Count);
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlDeleteDocumentTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlDeleteDocumentTests.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlDeleteDocumentTests
+    {
+        [Test]
+        public void ShouldDeleteDocumentFromDocumentOClassName()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    database
+                        .Create.Document("TestClass")
+                        .Set("foo", "foo string value1")
+                        .Set("bar", 12345)
+                        .Run();
+
+                    database
+                        .Create.Document("TestClass")
+                        .Set("foo", "foo string value2")
+                        .Set("bar", 54321)
+                        .Run();
+
+                    ODocument document = new ODocument();
+                    document.OClassName = "TestClass";
+
+                    int documentsDeleted = database
+                        .Delete.Document(document)
+                        .Run();
+
+                    Assert.AreEqual(documentsDeleted, 2);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldDeleteDocumentFromObjectOClassName()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class<TestProfileClass>()
+                        .Run();
+
+                    TestProfileClass profile = new TestProfileClass();
+                    profile.Name = "Johny";
+                    profile.Surname = "Bravo";
+
+                    database
+                        .Create.Document(profile)
+                        .Run();
+
+                    database
+                        .Create.Document(profile)
+                        .Run();
+
+                    int documentsDeleted = database
+                        .Delete.Document(profile)
+                        .Run();
+
+                    Assert.AreEqual(documentsDeleted, 2);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldDeleteDocumentFromDocumentOrid()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    ODocument document1 = database
+                        .Create.Document("TestClass")
+                        .Set("foo", "foo string value1")
+                        .Set("bar", 12345)
+                        .Run();
+
+                    ODocument document2 = database
+                        .Create.Document("TestClass")
+                        .Set("foo", "foo string value2")
+                        .Set("bar", 54321)
+                        .Run();
+
+                    ODocument document = new ODocument();
+                    document.OClassName = "TestClass";
+
+                    int documentsDeleted = database
+                        .Delete.Document(document2)
+                        .Run();
+
+                    Assert.AreEqual(documentsDeleted, 1);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldDeleteDocumentFromObjectOrid()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class<TestProfileClass>()
+                        .Run();
+
+                    TestProfileClass profile = new TestProfileClass();
+                    profile.Name = "Johny";
+                    profile.Surname = "Bravo";
+
+                    TestProfileClass document1 = database
+                        .Create.Document(profile)
+                        .Run<TestProfileClass>();
+
+                    TestProfileClass document2 = database
+                        .Create.Document(profile)
+                        .Run<TestProfileClass>();
+
+                    int documentsDeleted = database
+                        .Delete.Document(document2)
+                        .Run();
+
+                    Assert.AreEqual(documentsDeleted, 1);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldDeleteDocumentClassWhereQuery()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    database
+                        .Create.Document("TestClass")
+                        .Set("foo", "foo string value1")
+                        .Set("bar", 12345)
+                        .Run();
+
+                    database
+                        .Create.Document("TestClass")
+                        .Set("foo", "foo string value2")
+                        .Set("bar", 54321)
+                        .Run();
+
+                    ODocument document = new ODocument();
+                    document.OClassName = "TestClass";
+
+                    int documentsDeleted = database
+                        .Delete.Document("TestClass")
+                        .Where("bar").Equals(12345)
+                        .Run();
+
+                    Assert.AreEqual(documentsDeleted, 1);
+                }
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlDeleteEdgeTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlDeleteEdgeTests.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlDeleteEdgeTests
+    {
+        [Test]
+        public void ShouldDeleteEdgeFromDocumentOrid()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestVertexClass")
+                        .Extends<OVertex>()
+                        .Run();
+
+                    database
+                        .Create.Class("TestEdgeClass")
+                        .Extends<OEdge>()
+                        .Run();
+
+                    ODocument vertex1 = database
+                        .Create.Vertex("TestVertexClass")
+                        .Set("foo", "foo string value1")
+                        .Set("bar", 12345)
+                        .Run();
+
+                    ODocument vertex2 = database
+                        .Create.Vertex("TestVertexClass")
+                        .Set("foo", "foo string value2")
+                        .Set("bar", 54321)
+                        .Run();
+
+                    ODocument edge1 = database
+                        .Create.Edge("TestEdgeClass")
+                        .From(vertex1)
+                        .To(vertex2)
+                        .Set("foo", "foo string value2")
+                        .Set("bar", 54321)
+                        .Run();
+
+                    int documentsDeleted = database
+                        .Delete.Edge(edge1)
+                        .Run();
+
+                    Assert.AreEqual(documentsDeleted, 1);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldDeleteEdgeFromObjectOrid()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    database
+                        .Create.Class<TestProfileClass>()
+                        .Extends<OEdge>()
+                        .Run();
+
+                    ODocument vertex1 = database
+                        .Create.Vertex<OVertex>()
+                        .Set("foo", "foo string value1")
+                        .Set("bar", 12345)
+                        .Run();
+
+                    ODocument vertex2 = database
+                        .Create.Vertex<OVertex>()
+                        .Set("foo", "foo string value2")
+                        .Set("bar", 54321)
+                        .Run();
+
+                    ODocument edge1 = database
+                        .Create.Edge<TestProfileClass>()
+                        .From(vertex1)
+                        .To(vertex2)
+                        .Set("Name", "Johny")
+                        .Set("Surnam", "Bravo")
+                        .Run();
+
+                    int documentsDeleted = database
+                        .Delete.Edge(edge1)
+                        .Run();
+
+                    Assert.AreEqual(documentsDeleted, 1);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldDeleteEdgeFromClassWhere()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    ODocument vertex1 = database
+                        .Create.Vertex<OVertex>()
+                        .Set("foo", "foo string value1")
+                        .Set("bar", 12345)
+                        .Run();
+
+                    ODocument vertex2 = database
+                        .Create.Vertex<OVertex>()
+                        .Set("foo", "foo string value2")
+                        .Set("bar", 54321)
+                        .Run();
+
+                    ODocument edge1 = database
+                        .Create.Edge<OEdge>()
+                        .From(vertex1)
+                        .To(vertex2)
+                        .Set("foo", "foo string value2")
+                        .Set("bar", 54321)
+                        .Run();
+
+                    int documentsDeleted = database
+                        .Delete.Edge()
+                        .Class<OEdge>()
+                        .Where("bar").Equals(54321)
+                        .Run();
+
+                    Assert.AreEqual(documentsDeleted, 1);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldDeleteEdgeFromDocumentToDocument()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    ODocument vertex1 = database
+                        .Create.Vertex<OVertex>()
+                        .Set("foo", "foo string value1")
+                        .Set("bar", 12345)
+                        .Run();
+
+                    ODocument vertex2 = database
+                        .Create.Vertex<OVertex>()
+                        .Set("foo", "foo string value2")
+                        .Set("bar", 54321)
+                        .Run();
+
+                    ODocument edge1 = database
+                        .Create.Edge<OEdge>()
+                        .From(vertex1)
+                        .To(vertex2)
+                        .Set("foo", "foo string value2")
+                        .Set("bar", 54321)
+                        .Run();
+
+                    ODocument edge2 = database
+                        .Create.Edge<OEdge>()
+                        .From(vertex1)
+                        .To(vertex2)
+                        .Set("foo", "foo string value2")
+                        .Set("bar", 12345)
+                        .Run();
+
+                    string s = database
+                        .Delete.Edge<OEdge>()
+                        .From(vertex1)
+                        .To(vertex2)
+                        .ToString();
+
+                    int documentsDeleted = database
+                        .Delete.Edge<OEdge>()
+                        .From(vertex1)
+                        .To(vertex2)
+                        .Run();
+
+                    //Assert.AreEqual(2, documentsDeleted);
+                    Assert.AreEqual(0, documentsDeleted);
+                }
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlDeleteVertexTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlDeleteVertexTests.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlDeleteVertexTests
+    {
+        [Test]
+        public void ShouldDeleteVertexFromDocumentOrid()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestVertexClass")
+                        .Extends<OVertex>()
+                        .Run();
+
+                    ODocument vertex1 = database
+                        .Create.Vertex("TestVertexClass")
+                        .Set("foo", "foo string value1")
+                        .Set("bar", 12345)
+                        .Run();
+
+                    ODocument vertex2 = database
+                        .Create.Vertex("TestVertexClass")
+                        .Set("foo", "foo string value2")
+                        .Set("bar", 54321)
+                        .Run();
+
+                    int documentsDeleted = database
+                        .Delete.Vertex(vertex2)
+                        .Run();
+
+                    Assert.AreEqual(documentsDeleted, 1);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldDeleteVertexFromObjectOrid()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class<TestProfileClass>()
+                        .Extends<OVertex>()
+                        .Run();
+
+                    TestProfileClass vertex1 = database
+                        .Create.Vertex<TestProfileClass>()
+                        .Set("Name", "Johny")
+                        .Set("Surname", "Bravo")
+                        .Run<TestProfileClass>();
+
+                    TestProfileClass vertex2 = database
+                        .Create.Vertex<TestProfileClass>()
+                        .Set("Name", "Julia")
+                        .Set("Surname", "Bravo")
+                        .Run<TestProfileClass>();
+
+                    int documentsDeleted = database
+                        .Delete.Vertex(vertex2)
+                        .Run();
+
+                    Assert.AreEqual(documentsDeleted, 1);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldDeleteVertexFromClassWhere()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestVertexClass")
+                        .Extends<OVertex>()
+                        .Run();
+
+                    ODocument vertex1 = database
+                        .Create.Vertex("TestVertexClass")
+                        .Set("foo", "foo string value1")
+                        .Set("bar", 12345)
+                        .Run();
+
+                    ODocument vertex2 = database
+                        .Create.Vertex("TestVertexClass")
+                        .Set("foo", "foo string value2")
+                        .Set("bar", 54321)
+                        .Run();
+
+                    ODocument document = new ODocument();
+                    document.OClassName = "TestVertexClass";
+
+                    int documentsDeleted = database
+                        .Delete.Vertex()
+                        .Class("TestVertexClass")
+                        .Where("bar").Equals(12345)
+                        .Run();
+
+                    Assert.AreEqual(documentsDeleted, 1);
+                }
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlGenerateCreateClassQueryTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlGenerateCreateClassQueryTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlGenerateCreateClassQueryTests
+    {
+        [Test]
+        public void ShouldGenerateCreateClassQuery()
+        {
+            string generatedQuery = new OSqlCreateClass()
+                .Class("TestVertexClass")
+                .ToString();
+
+            string query =
+                "CREATE CLASS TestVertexClass";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateCreateClassExtendsQuery()
+        {
+            string generatedQuery = new OSqlCreateClass()
+                .Class("TestVertexClass")
+                .Extends("TestSuperClass")
+                .ToString();
+
+            string query =
+                "CREATE CLASS TestVertexClass " +
+                "EXTENDS TestSuperClass";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateCreateClassExtendsClusterQuery()
+        {
+            string generatedQuery = new OSqlCreateClass()
+                .Class("TestVertexClass")
+                .Extends("TestSuperClass")
+                .Cluster(8)
+                .ToString();
+
+            string query =
+                "CREATE CLASS TestVertexClass " +
+                "EXTENDS TestSuperClass " +
+                "CLUSTER 8";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlGenerateCreateClusterQueryTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlGenerateCreateClusterQueryTests.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlGenerateCreateClusterQueryTests
+    {
+        [Test]
+        public void ShouldGenerateCreateClusterQuery()
+        {
+            string generatedQuery = new OSqlCreateCluster()
+                .Cluster("TestVertexClass", OClusterType.Physical)
+                .ToString();
+
+            string query =
+                "CREATE CLUSTER TestVertexClass PHYSICAL";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlGenerateCreateDocumentQueryTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlGenerateCreateDocumentQueryTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+using Orient.Client.API.Query;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlGenerateCreateDocumentQueryTests
+    {
+        [Test]
+        public void ShouldGenerateInsertDocumentQuery()
+        {
+            ODocument document = new ODocument();
+            document.OClassName = "TestClass";
+            document
+                .SetField("foo", "foo string value")
+                .SetField("bar", 12345);
+
+            string generatedQuery = new OSqlCreateDocument()
+                .Document(document)
+                .ToString();
+
+            string query =
+                "INSERT INTO TestClass " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateInsertIntoClusterSetQuery()
+        {
+            ODocument document = new ODocument()
+                .SetField("foo", "foo string value")
+                .SetField("bar", 12345);
+
+            string generatedQuery = new OSqlCreateDocument()
+                .Document("TestClass")
+                .Cluster("TestCluster")
+                .Set(document)
+                .ToString();
+
+            string query =
+                "INSERT INTO TestClass " +
+                "CLUSTER TestCluster " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlGenerateCreateEdgeQueryTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlGenerateCreateEdgeQueryTests.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlGenerateCreateEdgeQueryTests
+    {
+        [Test]
+        public void ShouldGenerateCreateEdgeClusterFromToQuery()
+        {
+            string generatedQuery = new OSqlCreateEdge()
+                .Edge("TestEdgeClass")
+                .Cluster("TestCluster")
+                .From(new ORID(8, 0))
+                .To(new ORID(8, 1))
+                .ToString();
+
+            string query =
+                "CREATE EDGE TestEdgeClass " +
+                "CLUSTER TestCluster " +
+                "FROM #8:0 TO #8:1";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateCreateEdgeFromToSetQuery()
+        {
+            string generatedQuery = new OSqlCreateEdge()
+                .Edge("TestEdgeClass")
+                .From(new ORID(8, 0))
+                .To(new ORID(8, 1))
+                .Set("foo", "foo string value")
+                .Set("bar", 12345)
+                .ToString();
+
+            string query =
+                "CREATE EDGE TestEdgeClass " +
+                "FROM #8:0 TO #8:1 " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateCreateEdgeObjectFromDocumentToDocumentQuery()
+        {
+            TestProfileClass profile = new TestProfileClass();
+            profile.Name = "Johny";
+            profile.Surname = "Bravo";
+
+            ODocument vertexFrom = new ODocument();
+            vertexFrom.ORID = new ORID(8, 0);
+
+            ODocument vertexTo = new ODocument();
+            vertexTo.ORID = new ORID(8, 1);
+
+            string generatedQuery = new OSqlCreateEdge()
+                .Edge(profile)
+                .From(vertexFrom)
+                .To(vertexTo)
+                .ToString();
+
+            string query =
+                "CREATE EDGE TestProfileClass " +
+                "FROM #8:0 TO #8:1 " +
+                "SET Name = 'Johny', " +
+                "Surname = 'Bravo'";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateCreateEdgeObjectFromObjectToObjectQuery()
+        {
+            TestProfileClass profile = new TestProfileClass();
+            profile.Name = "Johny";
+            profile.Surname = "Bravo";
+
+            TestProfileClass vertexFrom = new TestProfileClass();
+            vertexFrom.ORID = new ORID(8, 0);
+
+            TestProfileClass vertexTo = new TestProfileClass();
+            vertexTo.ORID = new ORID(8, 1);
+
+            string generatedQuery = new OSqlCreateEdge()
+                .Edge(profile)
+                .From(vertexFrom)
+                .To(vertexTo)
+                .ToString();
+
+            string query =
+                "CREATE EDGE TestProfileClass " +
+                "FROM #8:0 TO #8:1 " +
+                "SET Name = 'Johny', " +
+                "Surname = 'Bravo'";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlGenerateCreateVertexQueryTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlGenerateCreateVertexQueryTests.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlGenerateCreateVertexQueryTests
+    {
+        [Test]
+        public void ShouldGenerateCreateVertexQuery()
+        {
+            string generatedQuery = new OSqlCreateVertex()
+                .Vertex("TestVertexClass")
+                .ToString();
+
+            string query =
+                "CREATE VERTEX TestVertexClass";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateCreateVertexFromDocumentQuery()
+        {
+            ODocument document = new ODocument();
+            document.OClassName = "TestVertexClass";
+            document
+                .SetField("foo", "foo string value")
+                .SetField("bar", 12345);
+
+            string generatedQuery = new OSqlCreateVertex()
+                .Vertex(document)
+                .ToString();
+
+            string query =
+                "CREATE VERTEX TestVertexClass " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateCreateVertexFromObjectQuery()
+        {
+            TestProfileClass profile = new TestProfileClass();
+            profile.Name = "Johny";
+            profile.Surname = "Bravo";
+
+            string generatedQuery = new OSqlCreateVertex()
+                .Vertex(profile)
+                .ToString();
+
+            string query =
+                "CREATE VERTEX TestProfileClass " +
+                "SET Name = 'Johny', " +
+                "Surname = 'Bravo'";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateCreateVertexClusterQuery()
+        {
+            string generatedQuery = new OSqlCreateVertex()
+                .Vertex("TestVertexClass")
+                .Cluster("TestCluster")
+                .ToString();
+
+            string query =
+                "CREATE VERTEX TestVertexClass " +
+                "CLUSTER TestCluster";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateCreateVertexClusterSetQuery()
+        {
+            string generatedQuery = new OSqlCreateVertex()
+                .Vertex("TestVertexClass")
+                .Cluster("TestCluster")
+                .Set("foo", "foo string value")
+                .Set("bar", 12345)
+                .ToString();
+
+            string query =
+                "CREATE VERTEX TestVertexClass " +
+                "CLUSTER TestCluster " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateCreateVertexClusterSetFromDocumentQuery()
+        {
+            ODocument document = new ODocument();
+            document.OClassName = "TestVertexClass";
+            document
+                .SetField("foo", "foo string value")
+                .SetField("bar", 12345);
+
+            string generatedQuery = new OSqlCreateVertex()
+                .Vertex("TestVertexClass")
+                .Cluster("TestCluster")
+                .Set(document)
+                .ToString();
+
+            string query =
+                "CREATE VERTEX TestVertexClass " +
+                "CLUSTER TestCluster " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlGenerateDeleteDocumentQueryTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlGenerateDeleteDocumentQueryTests.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlGenerateDeleteDocumentQueryTests
+    {
+        [Test]
+        public void ShouldGenerateDeleteDocumentFromDocumentOClassNameQuery()
+        {
+            ODocument document = new ODocument();
+            document.OClassName = "TestVertexClass";
+
+            string generatedQuery = new OSqlDeleteDocument()
+                .Delete(document)
+                .ToString();
+
+            string query =
+                "DELETE FROM TestVertexClass";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateDeleteDocumentFromObjectOClassNameQuery()
+        {
+            TestProfileClass profile = new TestProfileClass();
+
+            string generatedQuery = new OSqlDeleteDocument()
+                .Delete(profile)
+                .ToString();
+
+            string query =
+                "DELETE FROM TestProfileClass";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateDeleteDocumentFromDocumentOridQuery()
+        {
+            ODocument document = new ODocument();
+            document.OClassName = "TestVertexClass";
+            document.ORID = new ORID(8, 0);
+
+            string generatedQuery = new OSqlDeleteDocument()
+                .Delete(document)
+                .ToString();
+
+            string query =
+                "DELETE FROM TestVertexClass " +
+                "WHERE @rid = #8:0";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateDeleteDocumentFromObjectOridQuery()
+        {
+            TestProfileClass profile = new TestProfileClass();
+            profile.ORID = new ORID(8, 0);
+
+            string generatedQuery = new OSqlDeleteDocument()
+                .Delete(profile)
+                .ToString();
+
+            string query =
+                "DELETE FROM TestProfileClass " +
+                "WHERE @rid = #8:0";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateDeleteDocumentClassWhereLimitQuery()
+        {
+            string generatedQuery = new OSqlDeleteDocument()
+                .Class<TestProfileClass>()
+                .Where("foo").Equals("whoa")
+                .Or("foo").NotEquals(123)
+                .And("foo").Lesser(1)
+                .And("foo").LesserEqual(2)
+                .And("foo").Greater(3)
+                .And("foo").GreaterEqual(4)
+                .And("foo").Like("%whoa%")
+                .And("foo").IsNull()
+                .And("foo").Contains("johny")
+                .And("foo").Contains("name", "johny")
+                .Limit(5)
+                .ToString();
+
+            string query =
+                "DELETE FROM TestProfileClass " +
+                "WHERE foo = 'whoa' " +
+                "OR foo != 123 " +
+                "AND foo < 1 " +
+                "AND foo <= 2 " +
+                "AND foo > 3 " +
+                "AND foo >= 4 " +
+                "AND foo LIKE '%whoa%' " +
+                "AND foo IS NULL " +
+                "AND foo CONTAINS 'johny' " +
+                "AND foo CONTAINS (name = 'johny') " +
+                "LIMIT 5";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlGenerateDeleteEdgeQueryTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlGenerateDeleteEdgeQueryTests.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlGenerateDeleteEdgeQueryTests
+    {
+        [Test]
+        public void ShouldGenerateDeleteEdgeFromDocumentOridQuery()
+        {
+            ODocument document = new ODocument();
+            document.ORID = new ORID(8, 0);
+
+            string generatedQuery = new OSqlDeleteEdge()
+                .Delete(document)
+                .ToString();
+
+            string query =
+                "DELETE EDGE #8:0";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateDeleteEdgeFromObjectOridQuery()
+        {
+            TestProfileClass profile = new TestProfileClass();
+            profile.ORID = new ORID(8, 0);
+
+            string generatedQuery = new OSqlDeleteEdge()
+                .Delete(profile)
+                .ToString();
+
+            string query =
+                "DELETE EDGE #8:0";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateDeleteEdgeFromDocumentOClassNameQuery()
+        {
+            ODocument document = new ODocument();
+            document.OClassName = "TestClass";
+
+            string generatedQuery = new OSqlDeleteEdge()
+                .Delete(document)
+                .ToString();
+
+            string query =
+                "DELETE EDGE TestClass";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateDeleteEdgeFromObjectOClassNameQuery()
+        {
+            TestProfileClass profile = new TestProfileClass();
+
+            string generatedQuery = new OSqlDeleteEdge()
+                .Delete(profile)
+                .ToString();
+
+            string query =
+                "DELETE EDGE TestProfileClass";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateDeleteEdgeClassWhereLimitQuery()
+        {
+            string generatedQuery = new OSqlDeleteEdge()
+                .Class<TestProfileClass>()
+                .Where("foo").Equals("whoa")
+                .Or("foo").NotEquals(123)
+                .And("foo").Lesser(1)
+                .And("foo").LesserEqual(2)
+                .And("foo").Greater(3)
+                .And("foo").GreaterEqual(4)
+                .And("foo").Like("%whoa%")
+                .And("foo").IsNull()
+                .And("foo").Contains("johny")
+                .And("foo").Contains("name", "johny")
+                .Limit(5)
+                .ToString();
+
+            string query =
+                "DELETE EDGE TestProfileClass " +
+                "WHERE foo = 'whoa' " +
+                "OR foo != 123 " +
+                "AND foo < 1 " +
+                "AND foo <= 2 " +
+                "AND foo > 3 " +
+                "AND foo >= 4 " +
+                "AND foo LIKE '%whoa%' " +
+                "AND foo IS NULL " +
+                "AND foo CONTAINS 'johny' " +
+                "AND foo CONTAINS (name = 'johny') " +
+                "LIMIT 5";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateDeleteEdgeFromDocumentToDocumentQuery()
+        {
+            TestProfileClass profile = new TestProfileClass();
+
+            ODocument vertex1 = new ODocument();
+            vertex1.ORID = new ORID(8, 0);
+
+            ODocument vertex2 = new ODocument();
+            vertex2.ORID = new ORID(8, 1);
+
+            string generatedQuery = new OSqlDeleteEdge()
+                .Delete(profile)
+                .From(vertex1)
+                .To(vertex2)
+                .ToString();
+
+            string query =
+                "DELETE EDGE TestProfileClass FROM #8:0 TO #8:1";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateDeleteEdgeFromObjectToObjectQuery()
+        {
+            TestProfileClass profile = new TestProfileClass();
+
+            TestProfileClass vertex1 = new TestProfileClass();
+            vertex1.ORID = new ORID(8, 0);
+
+            TestProfileClass vertex2 = new TestProfileClass();
+            vertex2.ORID = new ORID(8, 1);
+
+            string generatedQuery = new OSqlDeleteEdge()
+                .Delete(profile)
+                .From(vertex1)
+                .To(vertex2)
+                .ToString();
+
+            string query =
+                "DELETE EDGE TestProfileClass FROM #8:0 TO #8:1";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlGenerateDeleteVertexQueryTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlGenerateDeleteVertexQueryTests.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlGenerateDeleteVertexQueryTests
+    {
+        [Test]
+        public void ShouldGenerateDeleteVertexFromDocumentOridQuery()
+        {
+            ODocument document = new ODocument();
+            document.ORID = new ORID(8, 0);
+
+            string generatedQuery = new OSqlDeleteVertex()
+                .Delete(document)
+                .ToString();
+
+            string query =
+                "DELETE VERTEX #8:0";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateDeleteVertexFromObjectOridQuery()
+        {
+            TestProfileClass profile = new TestProfileClass();
+            profile.ORID = new ORID(8, 0);
+
+            string generatedQuery = new OSqlDeleteVertex()
+                .Delete(profile)
+                .ToString();
+
+            string query =
+                "DELETE VERTEX #8:0";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateDeleteVertexFromDocumentOClassNameQuery()
+        {
+            ODocument document = new ODocument();
+            document.OClassName = "TestClass";
+
+            string generatedQuery = new OSqlDeleteVertex()
+                .Delete(document)
+                .ToString();
+
+            string query =
+                "DELETE VERTEX TestClass";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateDeleteVertexFromObjectOClassNameQuery()
+        {
+            TestProfileClass profile = new TestProfileClass();
+
+            string generatedQuery = new OSqlDeleteVertex()
+                .Delete(profile)
+                .ToString();
+
+            string query =
+                "DELETE VERTEX TestProfileClass";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateDeleteVertexClassWhereLimitQuery()
+        {
+            string generatedQuery = new OSqlDeleteVertex()
+                .Class<TestProfileClass>()
+                .Where("foo").Equals("whoa")
+                .Or("foo").NotEquals(123)
+                .And("foo").Lesser(1)
+                .And("foo").LesserEqual(2)
+                .And("foo").Greater(3)
+                .And("foo").GreaterEqual(4)
+                .And("foo").Like("%whoa%")
+                .And("foo").IsNull()
+                .And("foo").Contains("johny")
+                .And("foo").Contains("name", "johny")
+                .Limit(5)
+                .ToString();
+
+            string query =
+                "DELETE VERTEX TestProfileClass " +
+                "WHERE foo = 'whoa' " +
+                "OR foo != 123 " +
+                "AND foo < 1 " +
+                "AND foo <= 2 " +
+                "AND foo > 3 " +
+                "AND foo >= 4 " +
+                "AND foo LIKE '%whoa%' " +
+                "AND foo IS NULL " +
+                "AND foo CONTAINS 'johny' " +
+                "AND foo CONTAINS (name = 'johny') " +
+                "LIMIT 5";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlGenerateInsertQueryTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlGenerateInsertQueryTests.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlGenerateInsertQueryTests
+    {
+        [Test]
+        public void ShouldGenerateInsertDocumentQuery()
+        {
+            ODocument document = new ODocument();
+            document.OClassName = "TestClass";
+            document
+                .SetField("foo", "foo string value")
+                .SetField("bar", 12345);
+
+            string generatedQuery = new OSqlInsert()
+                .Insert(document)
+                .ToString();
+
+            string query =
+                "INSERT INTO TestClass " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateInsertObjectQuery()
+        {
+            TestProfileClass profile = new TestProfileClass();
+            profile.Name = "Johny";
+            profile.Surname = "Bravo";
+
+            string generatedQuery = new OSqlInsert()
+                .Insert(profile)
+                .ToString();
+
+            string query =
+                "INSERT INTO TestProfileClass " +
+                "SET Name = 'Johny', " +
+                "Surname = 'Bravo'";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateInsertDocumentIntoQuery()
+        {
+            ODocument document = new ODocument()
+                .SetField("foo", "foo string value")
+                .SetField("bar", 12345);
+
+            string generatedQuery = new OSqlInsert()
+                .Insert(document)
+                .Into("TestClass")
+                .ToString();
+
+            string query =
+                "INSERT INTO TestClass " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateInsertDocumentIntoClusterQuery()
+        {
+            ODocument document = new ODocument()
+                .SetField("foo", "foo string value")
+                .SetField("bar", 12345);
+
+            string generatedQuery = new OSqlInsert()
+                .Insert(document)
+                .Into("TestClass")
+                .Cluster("TestCluster")
+                .ToString();
+
+            string query =
+                "INSERT INTO TestClass " +
+                "CLUSTER TestCluster " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateInsertIntoClusterSetQuery()
+        {
+            string generatedQuery = new OSqlInsert()
+                .Into("TestClass")
+                .Cluster("TestCluster")
+                .Set("foo", "foo string value")
+                .Set("bar", 12345)
+                .ToString();
+
+            string query =
+                "INSERT INTO TestClass " +
+                "CLUSTER TestCluster " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlGenerateSelectQueryTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlGenerateSelectQueryTests.cs
@@ -1,0 +1,163 @@
+using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlGenerateSelectQueryTests
+    {
+        [Test]
+        public void ShouldGenerateSelectAlsoNthAsQuery()
+        {
+            string generatedQuery = new OSqlSelect()
+                .Select("foo").As("Foo")
+                .Also("bar").As("Bar")
+                .Also("baq").Nth(0).As("Baq")
+                .From("TestClass")
+                .ToString();
+
+            string query =
+                "SELECT foo AS Foo, " +
+                "bar AS Bar, " +
+                "baq[0] AS Baq " +
+                "FROM TestClass";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateSelectWhereLimitQuery()
+        {
+            string generatedQuery = new OSqlSelect()
+                .Select()
+                .From("TestClass")
+                .Where("foo").Equals("whoa")
+                .Or("foo").NotEquals(123)
+                .And("foo").Lesser(1)
+                .And("foo").LesserEqual(2)
+                .And("foo").Greater(3)
+                .And("foo").GreaterEqual(4)
+                .And("foo").Like("%whoa%")
+                .And("foo").IsNull()
+                .And("foo").Contains("johny")
+                .And("foo").Contains("name", "johny")
+                .And("foo").Between(1,2)
+                .And("foo").In(new[]{1,2})
+                .Limit(5)
+                .ToString();
+
+            string query =
+                "SELECT " +
+                "FROM TestClass " +
+                "WHERE foo = 'whoa' " +
+                "OR foo != 123 " +
+                "AND foo < 1 " +
+                "AND foo <= 2 " +
+                "AND foo > 3 " +
+                "AND foo >= 4 " +
+                "AND foo LIKE '%whoa%' " +
+                "AND foo IS NULL " +
+                "AND foo CONTAINS 'johny' " +
+                "AND foo CONTAINS (name = 'johny') " +
+                "AND foo BETWEEN 1 AND 2 "+
+                "AND foo IN [1,2] "+
+                "LIMIT 5";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateSelectFromDocumentOridQuery()
+        {
+            ODocument document = new ODocument();
+            document.ORID = new ORID(8, 0);
+
+            string generatedQuery = new OSqlSelect()
+                .Select("foo", "bar")
+                .From(document)
+                .ToString();
+
+            string query =
+                "SELECT foo, bar " +
+                "FROM #8:0";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateSelectFromDocumentOClassNameQuery()
+        {
+            ODocument document = new ODocument();
+            document.OClassName = "TestClass";
+
+            string generatedQuery = new OSqlSelect()
+                .Select("foo", "bar")
+                .From(document)
+                .ToString();
+
+            string query =
+                "SELECT foo, bar " +
+                "FROM TestClass";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateSelectFromOrderBySkipLimitQuery()
+        {
+            string generatedQuery = new OSqlSelect()
+                .Select()
+                .From("TestClass")
+                .OrderBy("foo", "bar")
+                .Skip(5)
+                .Limit(10)
+                .ToString();
+
+            string query =
+                "SELECT " +
+                "FROM TestClass " +
+                "ORDER BY foo, bar " +
+                "SKIP 5 " +
+                "LIMIT 10";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateSelectFromOrderByAscendingQuery()
+        {
+            string generatedQuery = new OSqlSelect()
+                .Select()
+                .From("TestClass")
+                .OrderBy("foo")
+                .Ascending()
+                .ToString();
+
+            string query =
+                "SELECT " +
+                "FROM TestClass " +
+                "ORDER BY foo ASC";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateSelectFromOrderByDescendingQuery()
+        {
+            string generatedQuery = new OSqlSelect()
+                .Select()
+                .From("TestClass")
+                .OrderBy("foo")
+                .Descending()
+                .ToString();
+
+            string query =
+                "SELECT " +
+                "FROM TestClass " +
+                "ORDER BY foo DESC";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlGenerateUpdateQueryTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlGenerateUpdateQueryTests.cs
@@ -1,0 +1,257 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlGenerateUpdateQueryTests
+    {
+        [Test]
+        public void ShouldGenerateUpdateClassFromDocumentQuery()
+        {
+            ODocument document = new ODocument();
+            document.OClassName = "TestVertexClass";
+            document
+                .SetField("foo", "foo string value")
+                .SetField("bar", 12345);
+
+            string generatedQuery = new OSqlUpdate()
+                .Update(document)
+                .ToString();
+
+            string query =
+                "UPDATE TestVertexClass " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateUpdateClassFromObjectQuery()
+        {
+            TestProfileClass profile = new TestProfileClass();
+            profile.Name = "Johny";
+            profile.Surname = "Bravo";
+
+            string generatedQuery = new OSqlUpdate()
+                .Update(profile)
+                .ToString();
+
+            string query =
+                "UPDATE TestProfileClass " +
+                "SET Name = 'Johny', " +
+                "Surname = 'Bravo'";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateUpdateClassQuery()
+        {
+            ODocument document = new ODocument()
+                .SetField("foo", "foo string value")
+                .SetField("bar", 12345);
+
+            string generatedQuery = new OSqlUpdate()
+                .Update(document)
+                .Class("TestVertexClass")
+                .ToString();
+
+            string query =
+                "UPDATE TestVertexClass " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateUpdateClusterQuery()
+        {
+            ODocument document = new ODocument()
+                .SetField("foo", "foo string value")
+                .SetField("bar", 12345);
+
+            string generatedQuery = new OSqlUpdate()
+                .Update(document)
+                .Cluster("TestCluster")
+                .ToString();
+
+            string query =
+                "UPDATE cluster:TestCluster " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateUpdateRecordFromDocumentQuery()
+        {
+            ODocument document = new ODocument();
+            document.ORID = new ORID(8, 0);
+            document
+                .SetField("foo", "foo string value")
+                .SetField("bar", 12345);
+
+            string generatedQuery = new OSqlUpdate()
+                .Update(document)
+                .ToString();
+
+            string query =
+                "UPDATE #8:0 " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateUpdateRecordFromOridQuery()
+        {
+            ODocument document = new ODocument()
+                .SetField("foo", "foo string value")
+                .SetField("bar", 12345);
+
+            string generatedQuery = new OSqlUpdate()
+                .Update(new ORID(8, 0))
+                .Set(document)
+                .ToString();
+
+            string query =
+                "UPDATE #8:0 " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateUpdateRecordQuery()
+        {
+            ODocument document = new ODocument()
+                .SetField("foo", "foo string value")
+                .SetField("bar", 12345);
+
+            string generatedQuery = new OSqlUpdate()
+                .Update(document)
+                .Record(new ORID(8, 0))
+                .ToString();
+
+            string query =
+                "UPDATE #8:0 " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateUpdateRecordSetQuery()
+        {
+            string generatedQuery = new OSqlUpdate()
+                .Record(new ORID(8, 0))
+                .Set("foo", "foo string value")
+                .Set("bar", 12345)
+                .ToString();
+
+            string query =
+                "UPDATE #8:0 " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateUpdateWhereLimitQuery()
+        {
+            ODocument document = new ODocument();
+            document.ORID = new ORID(8, 0);
+            document
+                .SetField("foo", "foo string value")
+                .SetField("bar", 12345);
+
+            string generatedQuery = new OSqlUpdate()
+                .Update(document)
+                .Where("foo").Equals("whoa")
+                .Or("foo").NotEquals(123)
+                .And("foo").Lesser(1)
+                .And("foo").LesserEqual(2)
+                .And("foo").Greater(3)
+                .And("foo").GreaterEqual(4)
+                .And("foo").Like("%whoa%")
+                .And("foo").IsNull()
+                .And("foo").Contains("johny")
+                .And("foo").Contains("name", "johny")
+                .Limit(5)
+                .ToString();
+
+            string query =
+                "UPDATE #8:0 " +
+                "SET foo = 'foo string value', " +
+                "bar = 12345 " +
+                "WHERE foo = 'whoa' " +
+                "OR foo != 123 " +
+                "AND foo < 1 " +
+                "AND foo <= 2 " +
+                "AND foo > 3 " +
+                "AND foo >= 4 " +
+                "AND foo LIKE '%whoa%' " +
+                "AND foo IS NULL " +
+                "AND foo CONTAINS 'johny' " +
+                "AND foo CONTAINS (name = 'johny') " +
+                "LIMIT 5";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateUpdateAddCollectionItemQuery()
+        {
+            string generatedQuery = new OSqlUpdate()
+                .Record(new ORID(8, 0))
+                .Add("foo", "foo string value")
+                .ToString();
+
+            string query =
+                "UPDATE #8:0 " +
+                "ADD foo = 'foo string value'";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateUpdateRemoveCollectionItemQuery()
+        {
+            string generatedQuery = new OSqlUpdate()
+                .Record(new ORID(8, 0))
+                .Remove("foo", 123)
+                .ToString();
+
+            string query =
+                "UPDATE #8:0 " +
+                "REMOVE foo = 123";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+
+        [Test]
+        public void ShouldGenerateUpdateRemoveFieldsQuery()
+        {
+            string generatedQuery = new OSqlUpdate()
+                .Record(new ORID(8, 0))
+                .Remove("foo")
+                .Remove("bar")
+                .ToString();
+
+            string query =
+                "UPDATE #8:0 " +
+                "REMOVE foo, bar";
+
+            Assert.AreEqual(generatedQuery, query);
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlInsertTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlInsertTests.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlInsertTests
+    {
+        [Test]
+        public void ShouldInsertDocument()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    ODocument document = new ODocument();
+                    document.OClassName = "TestClass";
+                    document
+                        .SetField("foo", "foo string value")
+                        .SetField("bar", 12345);
+
+                    ODocument insertedDocument = database
+                        .Insert(document)
+                        .Run();
+
+                    Assert.IsTrue(insertedDocument.ORID != null);
+                    Assert.AreEqual(insertedDocument.OClassName, "TestClass");
+                    Assert.AreEqual(insertedDocument.GetField<string>("foo"), document.GetField<string>("foo"));
+                    Assert.AreEqual(insertedDocument.GetField<int>("bar"), document.GetField<int>("bar"));
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldInsertObject()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class<TestProfileClass>()
+                        .Run();
+
+                    TestProfileClass profile = new TestProfileClass();
+                    profile.Name = "Johny";
+                    profile.Surname = "Bravo";
+
+                    TestProfileClass insertedDocument = database
+                        .Insert(profile)
+                        .Run<TestProfileClass>();
+
+                    Assert.IsTrue(insertedDocument.ORID != null);
+                    Assert.AreEqual(insertedDocument.OClassName, typeof(TestProfileClass).Name);
+                    Assert.AreEqual(insertedDocument.Name, profile.Name);
+                    Assert.AreEqual(insertedDocument.Surname, profile.Surname);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldInsertDocumentInto()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    ODocument document = new ODocument()
+                        .SetField("foo", "foo string value")
+                        .SetField("bar", 12345);
+
+                    ODocument insertedDocument = database
+                        .Insert(document)
+                        .Into("TestClass")
+                        .Run();
+
+                    Assert.IsTrue(insertedDocument.ORID != null);
+                    Assert.AreEqual(insertedDocument.OClassName, "TestClass");
+                    Assert.AreEqual(insertedDocument.GetField<string>("foo"), document.GetField<string>("foo"));
+                    Assert.AreEqual(insertedDocument.GetField<int>("bar"), document.GetField<int>("bar"));
+
+
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldInsertDocumentIntoCluster()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    database
+                        .Create.Cluster("TestCluster", OClusterType.Physical)
+                        .Run();
+
+                    database.Command("alter class TestClass addcluster TestCluster");
+
+                    ODocument document = new ODocument()
+                        .SetField("foo", "foo string value")
+                        .SetField("bar", 12345);
+
+                    ODocument insertedDocument = database
+                        .Insert(document)
+                        .Into("TestClass")
+                        .Cluster("TestCluster")
+                        .Run();
+
+                    Assert.IsTrue(insertedDocument.ORID != null);
+                    Assert.AreEqual(insertedDocument.OClassName, "TestClass");
+                    Assert.AreEqual(insertedDocument.GetField<string>("foo"), document.GetField<string>("foo"));
+                    Assert.AreEqual(insertedDocument.GetField<int>("bar"), document.GetField<int>("bar"));
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldInsertIntoClusterSet()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    database
+                        .Create.Cluster("TestCluster", OClusterType.Physical)
+                        .Run();
+                    
+                    database.Command("alter class TestClass addcluster TestCluster");
+
+                    ODocument insertedDocument = database
+                        .Insert()
+                        .Into("TestClass")
+                        .Cluster("TestCluster")
+                        .Set("foo", "foo string value")
+                        .Set("bar", 12345)
+                        .Run();
+
+                    Assert.IsTrue(insertedDocument.ORID != null);
+                    Assert.AreEqual(insertedDocument.OClassName, "TestClass");
+                    Assert.AreEqual(insertedDocument.GetField<string>("foo"), "foo string value");
+                    Assert.AreEqual(insertedDocument.GetField<int>("bar"), 12345);
+
+         
+                }
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlSelectTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlSelectTests.cs
@@ -1,0 +1,327 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlSelectTests
+    {
+        [Test]
+        public void ShouldSelectFromDocumentOrid()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    ODocument document1 = database
+                        .Insert()
+                        .Into("TestClass")
+                        .Set("foo", "foo string value1")
+                        .Set("bar", 12345)
+                        .Run();
+
+                    ODocument document2 = database
+                        .Insert()
+                        .Into("TestClass")
+                        .Set("foo", "foo string value2")
+                        .Set("bar", 54321)
+                        .Run();
+
+                    List<ODocument> documents = database
+                        .Select()
+                        .From(document2)
+                        .ToList();
+
+                    Assert.AreEqual(documents.Count, 1);
+
+                    for (int i = 0; i < documents.Count; i++)
+                    {
+                        Assert.AreEqual(documents[i].ORID, document2.ORID);
+                        Assert.AreEqual(documents[i].OClassName, document2.OClassName);
+                        Assert.AreEqual(documents[i].GetField<string>("foo"), document2.GetField<string>("foo"));
+                        Assert.AreEqual(documents[i].GetField<int>("bar"), document2.GetField<int>("bar"));
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldSelectFromDocumentOClassNameQuery()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    ODocument document1 = database
+                        .Insert()
+                        .Into("TestClass")
+                        .Set("foo", "foo string value1")
+                        .Set("bar", 12345)
+                        .Run();
+
+                    ODocument document2 = database
+                        .Insert()
+                        .Into("TestClass")
+                        .Set("foo", "foo string value2")
+                        .Set("bar", 54321)
+                        .Run();
+
+                    ODocument document = new ODocument();
+                    document.OClassName = "TestClass";
+
+                    List<ODocument> documents = database
+                        .Select()
+                        .From(document)
+                        .ToList();
+
+                    Assert.AreEqual(documents.Count, 2);
+
+                    for (int i = 0; i < documents.Count; i++)
+                    {
+                        Assert.IsTrue(documents[i].ORID != null);
+                        Assert.AreEqual(documents[i].OClassName, document.OClassName);
+                        Assert.IsTrue(documents[i].HasField("foo"));
+                        Assert.IsTrue(documents[i].HasField("bar"));
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldSelectToObjectList()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class<TestProfileClass>()
+                        .Run();
+
+                    TestProfileClass document1 = database
+                        .Insert()
+                        .Into<TestProfileClass>()
+                        .Set("Name", "Johny")
+                        .Set("Surname", "Bravo")
+                        .Run<TestProfileClass>();
+
+                    TestProfileClass document2 = database
+                        .Insert()
+                        .Into<TestProfileClass>()
+                        .Set("Name", "Johny")
+                        .Set("Surname", "Bravo")
+                        .Run<TestProfileClass>();
+
+                    List<TestProfileClass> documents = database
+                        .Select()
+                        .From<TestProfileClass>()
+                        .ToList<TestProfileClass>();
+
+                    Assert.AreEqual(documents.Count, 2);
+
+                    Assert.AreEqual(documents[0].ORID, document1.ORID);
+                    Assert.AreEqual(documents[0].OClassName, document1.OClassName);
+                    Assert.AreEqual(documents[0].Name, document1.Name);
+                    Assert.AreEqual(documents[0].Surname, document1.Surname);
+
+                    Assert.AreEqual(documents[1].ORID, document2.ORID);
+                    Assert.AreEqual(documents[1].OClassName, document2.OClassName);
+                    Assert.AreEqual(documents[1].Name, document2.Name);
+                    Assert.AreEqual(documents[1].Surname, document2.Surname);
+                }
+            }
+        }
+        
+        [Test]
+        public void ShouldSelectAsAnd()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class<TestVertexClass>()
+                        .Extends<OVertex>()
+                        .Run();
+
+                    TestVertexClass obj1 = new TestVertexClass();
+                    obj1.Foo = "foo string value1";
+                    obj1.Bar = 12345;
+
+                    TestVertexClass obj2 = new TestVertexClass();
+                    obj2.Foo = "foo string value2";
+                    obj2.Bar = 54321;
+
+                    database
+                        .Create.Vertex<TestVertexClass>()
+                        .Set(obj1)
+                        .Run();
+
+                    database
+                        .Create.Vertex<TestVertexClass>()
+                        .Set(obj2)
+                        .Run();
+
+                    List<ODocument> result = database
+                        .Select("Foo").As("CustomFoo")
+                        .Also("Bar").As("CustomBar")
+                        .From<TestVertexClass>()
+                        .ToList();
+
+                    Assert.AreEqual(result.Count, 2);
+                    Assert.AreEqual(result[0].GetField<string>("CustomFoo"), obj1.Foo);
+                    Assert.AreEqual(result[0].GetField<int>("CustomBar"), obj1.Bar);
+                    Assert.AreEqual(result[1].GetField<string>("CustomFoo"), obj2.Foo);
+                    Assert.AreEqual(result[1].GetField<int>("CustomBar"), obj2.Bar);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldSelectSkipLimit()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class<TestVertexClass>()
+                        .Extends<OVertex>()
+                        .Run();
+
+                    TestVertexClass obj1 = new TestVertexClass();
+                    obj1.Foo = "foo string value1";
+                    obj1.Bar = 1;
+
+                    TestVertexClass obj2 = new TestVertexClass();
+                    obj2.Foo = "foo string value2";
+                    obj2.Bar = 2;
+
+                    TestVertexClass obj3 = new TestVertexClass();
+                    obj3.Foo = "foo string value3";
+                    obj3.Bar = 3;
+
+                    TestVertexClass obj4 = new TestVertexClass();
+                    obj4.Foo = "foo string value4";
+                    obj4.Bar = 4;
+
+                    TestVertexClass obj5 = new TestVertexClass();
+                    obj5.Foo = "foo string value5";
+                    obj5.Bar = 5;
+
+                    database
+                        .Create.Vertex<TestVertexClass>()
+                        .Set(obj1)
+                        .Run();
+
+                    database
+                        .Create.Vertex<TestVertexClass>()
+                        .Set(obj2)
+                        .Run();
+
+                    database
+                        .Create.Vertex<TestVertexClass>()
+                        .Set(obj3)
+                        .Run();
+
+                    database
+                        .Create.Vertex<TestVertexClass>()
+                        .Set(obj4)
+                        .Run();
+
+                    database
+                        .Create.Vertex<TestVertexClass>()
+                        .Set(obj5)
+                        .Run();
+
+                    List<ODocument> result = database
+                        .Select("Foo").As("CustomFoo")
+                        .Also("Bar").As("CustomBar")
+                        .From<TestVertexClass>()
+                        .Skip(2)
+                        .Limit(2)
+                        .ToList();
+
+                    Assert.AreEqual(result.Count, 2);
+                    Assert.AreEqual(result[0].GetField<string>("CustomFoo"), obj3.Foo);
+                    Assert.AreEqual(result[0].GetField<int>("CustomBar"), obj3.Bar);
+                    Assert.AreEqual(result[1].GetField<string>("CustomFoo"), obj4.Foo);
+                    Assert.AreEqual(result[1].GetField<int>("CustomBar"), obj4.Bar);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldSelectOrderByDescending()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class<TestVertexClass>()
+                        .Extends<OVertex>()
+                        .Run();
+
+                    TestVertexClass obj1 = new TestVertexClass();
+                    obj1.Foo = "foo string value1";
+                    obj1.Bar = 1;
+
+                    TestVertexClass obj2 = new TestVertexClass();
+                    obj2.Foo = "foo string value2";
+                    obj2.Bar = 2;
+
+                    TestVertexClass obj3 = new TestVertexClass();
+                    obj3.Foo = "foo string value3";
+                    obj3.Bar = 3;
+
+                    database
+                        .Create.Vertex<TestVertexClass>()
+                        .Set(obj1)
+                        .Run();
+
+                    database
+                        .Create.Vertex<TestVertexClass>()
+                        .Set(obj2)
+                        .Run();
+
+                    database
+                        .Create.Vertex<TestVertexClass>()
+                        .Set(obj3)
+                        .Run();
+
+                    List<ODocument> result = database
+                        .Select("Foo").As("CustomFoo")
+                        .Also("Bar").As("CustomBar")
+                        .From<TestVertexClass>()
+                        .OrderBy("CustomBar").Descending()
+                        .ToList();
+
+                    Assert.AreEqual(result.Count, 3);
+                    Assert.AreEqual(result[0].GetField<string>("CustomFoo"), obj3.Foo);
+                    Assert.AreEqual(result[0].GetField<int>("CustomBar"), obj3.Bar);
+                    Assert.AreEqual(result[1].GetField<string>("CustomFoo"), obj2.Foo);
+                    Assert.AreEqual(result[1].GetField<int>("CustomBar"), obj2.Bar);
+                    Assert.AreEqual(result[2].GetField<string>("CustomFoo"), obj1.Foo);
+                    Assert.AreEqual(result[2].GetField<int>("CustomBar"), obj1.Bar);
+                }
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/SqlUpdateTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlUpdateTests.cs
@@ -1,0 +1,668 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlUpdateTests
+    {
+        [Test]
+        public void ShouldUpdateClassFromDocument()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    ODocument document = new ODocument();
+                    document.OClassName = "TestClass";
+                    document
+                        .SetField("foo", "foo string value")
+                        .SetField("bar", 12345);
+
+                    database
+                        .Insert(document)
+                        .Run();
+
+                    database
+                        .Insert(document)
+                        .Run();
+
+                    document
+                        .SetField("bar", 54321)
+                        .SetField("baz", "new baz value");
+
+                    int documentsUpdated = database
+                        .Update(document)
+                        .Run();
+
+                    Assert.AreEqual(documentsUpdated, 2);
+
+                    List<ODocument> documents = database
+                        .Select()
+                        .From("TestClass")
+                        .ToList();
+
+                    Assert.AreEqual(documents.Count, 2);
+
+                    for (int i = 0; i < documents.Count; i++)
+                    {
+                        Assert.IsTrue(documents[i].ORID != null);
+                        Assert.AreEqual(documents[i].OClassName, document.OClassName);
+                        Assert.AreEqual(documents[i].GetField<string>("foo"), document.GetField<string>("foo"));
+                        Assert.AreEqual(documents[i].GetField<int>("bar"), document.GetField<int>("bar"));
+                        Assert.AreEqual(documents[i].GetField<string>("baz"), document.GetField<string>("baz"));
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldUpdateClassFromObject()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class<TestProfileClass>()
+                        .Run();
+
+                    TestProfileClass profile = new TestProfileClass();
+                    profile.Name = "Johny";
+
+                    database
+                        .Insert(profile)
+                        .Run();
+
+                    database
+                        .Insert(profile)
+                        .Run();
+
+                    profile.Name = "Julia";
+                    profile.Surname = "Bravo";
+
+                    int documentsUpdated = database
+                        .Update(profile)
+                        .Run();
+
+                    Assert.AreEqual(documentsUpdated, 2);
+
+                    List<TestProfileClass> documents = database
+                        .Select()
+                        .From<TestProfileClass>()
+                        .ToList<TestProfileClass>();
+
+                    Assert.AreEqual(documents.Count, 2);
+
+                    for (int i = 0; i < documents.Count; i++)
+                    {
+                        Assert.IsTrue(documents[i].ORID != null);
+                        Assert.AreEqual(documents[i].OClassName, typeof(TestProfileClass).Name);
+                        Assert.AreEqual(documents[i].Name, profile.Name);
+                        Assert.AreEqual(documents[i].Surname, profile.Surname);
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldUpdateClass()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    ODocument document = new ODocument();
+                    document
+                        .SetField("foo", "foo string value")
+                        .SetField("bar", 12345);
+
+                    database
+                        .Insert(document)
+                        .Into("TestClass")
+                        .Run();
+
+                    database
+                        .Insert(document)
+                        .Into("TestClass")
+                        .Run();
+
+                    document
+                        .SetField("bar", 54321)
+                        .SetField("baz", "new baz value");
+
+                    int documentsUpdated = database
+                        .Update(document)
+                        .Class("TestClass")
+                        .Run();
+
+                    Assert.AreEqual(documentsUpdated, 2);
+
+                    List<ODocument> documents = database
+                        .Select()
+                        .From("TestClass")
+                        .ToList();
+
+                    Assert.AreEqual(documents.Count, 2);
+
+                    for (int i = 0; i < documents.Count; i++)
+                    {
+                        Assert.IsTrue(documents[i].ORID != null);
+                        Assert.AreEqual(documents[i].OClassName, "TestClass");
+                        Assert.AreEqual(documents[i].GetField<string>("foo"), document.GetField<string>("foo"));
+                        Assert.AreEqual(documents[i].GetField<int>("bar"), document.GetField<int>("bar"));
+                        Assert.AreEqual(documents[i].GetField<string>("baz"), document.GetField<string>("baz"));
+                    }
+                }
+            }
+        }
+
+        
+        [Test]
+        public void ShouldUpdateCluster()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    database
+                        .Create.Cluster("TestCluster", OClusterType.Physical)
+                        .Run();
+
+                    database.Command("alter class TestClass addcluster TestCluster");
+
+                    ODocument document = new ODocument();
+                    document.OClassName = "TestClass";
+                    document
+                        .SetField("foo", "foo string value")
+                        .SetField("bar", 12345);
+
+                    database
+                        .Insert(document)
+                        .Cluster("TestCluster")
+                        .Run();
+
+                    database
+                        .Insert(document)
+                        .Cluster("TestCluster")
+                        .Run();
+
+                    document
+                        .SetField("bar", 54321)
+                        .SetField("baz", "new baz value");
+
+                    int documentsUpdated = database
+                        .Update(document)
+                        .Cluster("TestCluster")
+                        .Run();
+
+                    Assert.AreEqual(documentsUpdated, 2);
+
+                    List<ODocument> documents = database
+                        .Select()
+                        .From("cluster:TestCluster")
+                        .ToList();
+
+                    Assert.AreEqual(documents.Count, 2);
+
+                    for (int i = 0; i < documents.Count; i++)
+                    {
+                        Assert.IsTrue(documents[i].ORID != null);
+                        Assert.AreEqual(documents[i].OClassName, document.OClassName);
+                        Assert.AreEqual(documents[i].GetField<string>("foo"), document.GetField<string>("foo"));
+                        Assert.AreEqual(documents[i].GetField<int>("bar"), document.GetField<int>("bar"));
+                        Assert.AreEqual(documents[i].GetField<string>("baz"), document.GetField<string>("baz"));
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldUpdateRecordFromDocument()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    ODocument document = new ODocument();
+                    document.OClassName = "TestClass";
+                    document
+                        .SetField("foo", "foo string value")
+                        .SetField("bar", 12345);
+
+                    ODocument document1 = database
+                        .Insert(document)
+                        .Run();
+
+                    ODocument document2 = database
+                        .Insert(document)
+                        .Run();
+
+                    document2
+                        .SetField("bar", 54321)
+                        .SetField("baz", "new baz value");
+
+                    int documentsUpdated = database
+                        .Update(document2)
+                        .Run();
+
+                    Assert.AreEqual(documentsUpdated, 1);
+
+                    List<ODocument> documents = database
+                        .Select()
+                        .From("TestClass")
+                        .Where("bar").Equals(54321)
+                        .ToList();
+
+                    Assert.AreEqual(documents.Count, 1);
+
+                    for (int i = 0; i < documents.Count; i++)
+                    {
+                        Assert.AreEqual(documents[i].ORID, document2.ORID);
+                        Assert.AreEqual(documents[i].OClassName, document2.OClassName);
+                        Assert.AreEqual(documents[i].GetField<string>("foo"), document2.GetField<string>("foo"));
+                        Assert.AreEqual(documents[i].GetField<int>("bar"), document2.GetField<int>("bar"));
+                        Assert.AreEqual(documents[i].GetField<string>("baz"), document2.GetField<string>("baz"));
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldUpdateOridSet()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    ODocument document = new ODocument();
+                    document.OClassName = "TestClass";
+                    document
+                        .SetField("foo", "foo string value")
+                        .SetField("bar", 12345);
+
+                    ODocument document1 = database
+                        .Insert(document)
+                        .Run();
+
+                    ODocument document2 = database
+                        .Insert(document)
+                        .Run();
+
+                    document2
+                        .SetField("bar", 54321)
+                        .SetField("baz", "new baz value");
+
+                    int documentsUpdated = database
+                        .Update(document2.ORID)
+                        .Set(document2)
+                        .Run();
+
+                    Assert.AreEqual(documentsUpdated, 1);
+
+                    List<ODocument> documents = database
+                        .Select()
+                        .From("TestClass")
+                        .Where("bar").Equals(54321)
+                        .ToList();
+
+                    Assert.AreEqual(documents.Count, 1);
+
+                    for (int i = 0; i < documents.Count; i++)
+                    {
+                        Assert.AreEqual(documents[i].ORID, document2.ORID);
+                        Assert.AreEqual(documents[i].OClassName, document2.OClassName);
+                        Assert.AreEqual(documents[i].GetField<string>("foo"), document2.GetField<string>("foo"));
+                        Assert.AreEqual(documents[i].GetField<int>("bar"), document2.GetField<int>("bar"));
+                        Assert.AreEqual(documents[i].GetField<string>("baz"), document2.GetField<string>("baz"));
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldUpdateRecord()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    ODocument document = new ODocument();
+                    document.OClassName = "TestClass";
+                    document
+                        .SetField("foo", "foo string value")
+                        .SetField("bar", 12345);
+
+                    ODocument document1 = database
+                        .Insert(document)
+                        .Run();
+
+                    ODocument document2 = database
+                        .Insert(document)
+                        .Run();
+
+                    ODocument docToUpdate = new ODocument()
+                        .SetField("bar", 54321)
+                        .SetField("baz", "new baz value");
+
+                    int documentsUpdated = database
+                        .Update(docToUpdate)
+                        .Record(document2.ORID)
+                        .Run();
+
+                    Assert.AreEqual(documentsUpdated, 1);
+
+                    List<ODocument> documents = database
+                        .Select()
+                        .From("TestClass")
+                        .Where("bar").Equals(54321)
+                        .ToList();
+
+                    Assert.AreEqual(documents.Count, 1);
+
+                    Assert.AreEqual(documents[0].ORID, document2.ORID);
+                    Assert.AreEqual(documents[0].OClassName, document2.OClassName);
+                    Assert.AreEqual(documents[0].GetField<string>("foo"), document2.GetField<string>("foo"));
+                    Assert.AreEqual(documents[0].GetField<int>("bar"), docToUpdate.GetField<int>("bar"));
+                    Assert.AreEqual(documents[0].GetField<string>("baz"), docToUpdate.GetField<string>("baz"));
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldUpdateRecordSet()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    ODocument document = new ODocument();
+                    document.OClassName = "TestClass";
+                    document
+                        .SetField("foo", "foo string value")
+                        .SetField("bar", 12345);
+
+                    ODocument document1 = database
+                        .Insert(document)
+                        .Run();
+
+                    ODocument document2 = database
+                        .Insert(document)
+                        .Run();
+
+                    int documentsUpdated = database
+                        .Update(document2.ORID)
+                        .Set("bar", 54321)
+                        .Set("baz", "new baz value")
+                        .Run();
+
+                    Assert.AreEqual(documentsUpdated, 1);
+
+                    List<ODocument> documents = database
+                        .Select()
+                        .From("TestClass")
+                        .Where("bar").Equals(54321)
+                        .ToList();
+
+                    Assert.AreEqual(documents.Count, 1);
+
+                    Assert.AreEqual(documents[0].ORID, document2.ORID);
+                    Assert.AreEqual(documents[0].OClassName, document2.OClassName);
+                    Assert.AreEqual(documents[0].GetField<string>("foo"), document2.GetField<string>("foo"));
+                    Assert.AreEqual(documents[0].GetField<int>("bar"), 54321);
+                    Assert.AreEqual(documents[0].GetField<string>("baz"), "new baz value");
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldUpdateWhere()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    ODocument document1 = database
+                        .Insert()
+                        .Into("TestClass")
+                        .Set("foo", "foo string value")
+                        .Set("bar", 11111)
+                        .Run();
+
+                    ODocument document2 = database
+                        .Insert()
+                        .Into("TestClass")
+                        .Set("foo", "foo string value")
+                        .Set("bar", 12345)
+                        .Run();
+
+                    int documentsUpdated = database
+                        .Update()
+                        .Class("TestClass")
+                        .Set("bar", 54321)
+                        .Set("baz", "new baz value")
+                        .Where("bar").Equals(12345)
+                        .Run();
+
+                    Assert.AreEqual(documentsUpdated, 1);
+
+                    List<ODocument> documents = database
+                        .Select()
+                        .From("TestClass")
+                        .Where("bar").Equals(54321)
+                        .ToList();
+
+                    Assert.AreEqual(documents.Count, 1);
+
+                    Assert.AreEqual(documents[0].ORID, document2.ORID);
+                    Assert.AreEqual(documents[0].OClassName, document2.OClassName);
+                    Assert.AreEqual(documents[0].GetField<string>("foo"), document2.GetField<string>("foo"));
+                    Assert.AreEqual(documents[0].GetField<int>("bar"), 54321);
+                    Assert.AreEqual(documents[0].GetField<string>("baz"), "new baz value");
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldUpdateAddCollectionItem()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    ODocument document1 = database
+                        .Insert()
+                        .Into("TestClass")
+                        .Set("foo", new List<string>() { "foo1", "foo2" })
+                        .Set("bar", 11111)
+                        .Run();
+
+                    ODocument document2 = database
+                        .Insert()
+                        .Into("TestClass")
+                        .Set("foo", new List<string>() { "foo1", "foo2" })
+                        .Set("bar", 12345)
+                        .Run();
+
+                    int documentsUpdated = database
+                        .Update(document2)
+                        .Add("foo", "foo3")
+                        .Run();
+
+                    Assert.AreEqual(documentsUpdated, 1);
+
+                    List<ODocument> documents = database
+                        .Select()
+                        .From("TestClass")
+                        .Where("bar").Equals(12345)
+                        .ToList();
+
+                    Assert.AreEqual(documents.Count, 1);
+
+                    Assert.AreEqual(documents[0].ORID, document2.ORID);
+                    Assert.AreEqual(documents[0].OClassName, document2.OClassName);
+
+                    List<string> foos = new List<string>() { "foo1", "foo2", "foo3" };
+
+                    Assert.AreEqual(documents[0].GetField<List<string>>("foo").Count, foos.Count);
+                    Assert.AreEqual(documents[0].GetField<List<string>>("foo")[0], foos[0]);
+                    Assert.AreEqual(documents[0].GetField<List<string>>("foo")[1], foos[1]);
+                    Assert.AreEqual(documents[0].GetField<List<string>>("foo")[2], foos[2]);
+
+                    Assert.AreEqual(documents[0].GetField<int>("bar"), document2.GetField<int>("bar"));
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldUpdateRemoveCollectionItem()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    ODocument document1 = database
+                        .Insert()
+                        .Into("TestClass")
+                        .Set("foo", new List<string>() { "foo1", "foo2" })
+                        .Set("bar", 11111)
+                        .Run();
+
+                    ODocument document2 = database
+                        .Insert()
+                        .Into("TestClass")
+                        .Set("foo", new List<string>() { "foo1", "foo2" })
+                        .Set("bar", 12345)
+                        .Run();
+
+                    int documentsUpdated = database
+                        .Update(document2)
+                        .Remove("foo", "foo2")
+                        .Run();
+
+                    Assert.AreEqual(documentsUpdated, 1);
+
+                    List<ODocument> documents = database
+                        .Select()
+                        .From("TestClass")
+                        .Where("bar").Equals(12345)
+                        .ToList();
+
+                    Assert.AreEqual(documents.Count, 1);
+
+                    Assert.AreEqual(documents[0].ORID, document2.ORID);
+                    Assert.AreEqual(documents[0].OClassName, document2.OClassName);
+
+                    List<string> foos = new List<string>() { "foo1" };
+
+                    Assert.AreEqual(documents[0].GetField<List<string>>("foo").Count, foos.Count);
+                    Assert.AreEqual(documents[0].GetField<List<string>>("foo")[0], foos[0]);
+
+                    Assert.AreEqual(documents[0].GetField<int>("bar"), document2.GetField<int>("bar"));
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldUpdateRemoveFieldQuery()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestClass")
+                        .Run();
+
+                    ODocument document1 = database
+                        .Insert()
+                        .Into("TestClass")
+                        .Set("foo", "foo string value1")
+                        .Set("bar", 11111)
+                        .Run();
+
+                    ODocument document2 = database
+                        .Insert()
+                        .Into("TestClass")
+                        .Set("foo", "foo string value2")
+                        .Set("bar", 12345)
+                        .Run();
+
+                    int documentsUpdated = database
+                        .Update(document2)
+                        .Remove("bar")
+                        .Run();
+
+                    Assert.AreEqual(documentsUpdated, 1);
+
+                    List<ODocument> documents = database
+                        .Select()
+                        .From("TestClass")
+                        .Where("foo").Equals("foo string value2")
+                        .ToList();
+
+                    Assert.AreEqual(documents.Count, 1);
+
+                    Assert.AreEqual(documents[0].ORID, document2.ORID);
+                    Assert.AreEqual(documents[0].OClassName, document2.OClassName);
+                    Assert.AreEqual(documents[0].GetField<string>("foo"), document2.GetField<string>("foo"));
+                    Assert.IsFalse(documents[0].HasField("bar"));
+                }
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/TestCreateVertex.cs
+++ b/src/Orient/Orient.NUnit/Query/TestCreateVertex.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class TestCreateVertex
+    {
+        [Test]
+        public void ShouldCreateVertex()
+        {
+            using (var context = new TestDatabaseContext())
+            using (var database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                //var document = database.Command("create vertex set  bar=1").ToSingle();
+                var d = database.Create.Vertex<OVertex>().Run();
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/TestRecordMetadata.cs
+++ b/src/Orient/Orient.NUnit/Query/TestRecordMetadata.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+using Orient.Client.API.Query;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class TestRecordMetadata
+    {
+        [Test]
+        public void ShouldRetrieveRecordMetadata()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    database
+                        .Create
+                        .Class("TestClass")
+                        .Run();
+
+                    var document = new ODocument();
+                    document.OClassName = "TestClass";
+                    document.SetField("bar", 12345);
+                    document.SetField("foo", "foo value 345");
+
+                    var createdDocument = database
+                        .Create
+                        .Document(document)
+                        .Run();
+
+                    var metadata = database
+                        .Metadata
+                        .ORID(createdDocument.ORID)
+                        .Run();
+                    Assert.IsNotNull(metadata);
+                    Assert.AreEqual(createdDocument.ORID, metadata.ORID);
+                    Assert.AreEqual(createdDocument.OVersion, metadata.OVersion);
+
+                }
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/TestTransactions.cs
+++ b/src/Orient/Orient.NUnit/Query/TestTransactions.cs
@@ -1,0 +1,260 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class TestTransactions
+    {
+        [Test]
+        public void TestUpdateVertex()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                ORID orid;
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestVertexClass")
+                        .Extends<OVertex>()
+                        .Run();
+
+                    OVertex testVertex = new OVertex();
+                    testVertex.OClassName = "TestVertexClass";
+                    testVertex.SetField("foo", "foo string value");
+                    testVertex.SetField("bar", 12345);
+
+                    Assert.AreEqual(null, testVertex.ORID);
+
+                    database.Transaction.Add(testVertex);
+
+                    Assert.IsNotNull(testVertex.ORID);
+                    Assert.IsTrue(testVertex.ORID.ClusterPosition < 0);
+                    Assert.AreEqual(-2, testVertex.ORID.ClusterPosition);
+
+                    database.Transaction.Commit();
+                    orid = testVertex.ORID;
+                }
+
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+
+                    OVertex v = database.Load.ORID(orid).Run().To<OVertex>();
+                    v.SetField("foobar", "blah");
+                    database.Transaction.Update(v);
+
+                    database.Transaction.Commit();
+                }
+
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+
+                    OVertex v = database.Load.ORID(orid).Run().To<OVertex>();
+                    Assert.AreEqual("blah", v.GetField<string>("foobar"));
+                }
+
+            }
+        }
+
+        [Test]
+        public void TestCreateVertex()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestVertexClass")
+                        .Extends<OVertex>()
+                        .Run();
+
+                    OVertex testVertex = new OVertex();
+                    testVertex.OClassName = "TestVertexClass";
+                    testVertex.SetField("foo", "foo string value");
+                    testVertex.SetField("bar", 12345);
+
+                    Assert.AreEqual(null, testVertex.ORID);
+
+                    database.Transaction.Add(testVertex);
+
+                    Assert.IsNotNull(testVertex.ORID);
+                    Assert.IsTrue(testVertex.ORID.ClusterPosition < 0);
+                    Assert.AreEqual(-2, testVertex.ORID.ClusterPosition);
+
+                    database.Transaction.Commit();
+
+                    Assert.IsNotNull(testVertex.ORID);
+                    Assert.AreEqual(database.GetClusterIdFor("TestVertexClass"), testVertex.ORID.ClusterId);
+
+                    var createdVertex = database.Load.ORID(testVertex.ORID).Run().To<OVertex>();
+
+                    Assert.IsTrue(createdVertex.ORID != null);
+                    Assert.AreEqual("TestVertexClass", createdVertex.OClassName);
+                    Assert.AreEqual("foo string value", createdVertex.GetField<string>("foo"));
+                    Assert.AreEqual(12345, createdVertex.GetField<int>("bar"));
+                }
+
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+
+
+                    OVertex testVertex = new OVertex();
+                    testVertex.OClassName = "TestVertexClass";
+                    testVertex.SetField("foo", "foo string value");
+                    testVertex.SetField("bar", 12345);
+
+                    Assert.AreEqual(null, testVertex.ORID);
+
+                    database.Transaction.Add(testVertex);
+
+                    Assert.IsNotNull(testVertex.ORID);
+                    Assert.IsTrue(testVertex.ORID.ClusterPosition < 0);
+                    Assert.AreEqual(-2, testVertex.ORID.ClusterPosition);
+
+                    database.Transaction.Commit();
+
+                    Assert.IsNotNull(testVertex.ORID);
+                    Assert.AreEqual(database.GetClusterIdFor("TestVertexClass"), testVertex.ORID.ClusterId);
+                    Assert.AreNotEqual(-2, testVertex.ORID.ClusterPosition);
+
+                    var createdVertex = database.Load.ORID(testVertex.ORID).Run().To<OVertex>();
+
+                    Assert.IsTrue(createdVertex.ORID != null);
+                    Assert.AreEqual(createdVertex.OClassName, "TestVertexClass");
+                    Assert.AreEqual(createdVertex.GetField<string>("foo"), "foo string value");
+                    Assert.AreEqual(createdVertex.GetField<int>("bar"), 12345);
+                }
+
+            }
+        }
+
+        [Test]
+        public void TestCreateManyVertices()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestVertexClass")
+                        .Extends<OVertex>()
+                        .Run();
+
+                    for (int i = 0; i < 1000; i++)
+                    {
+                        OVertex testVertex = new OVertex();
+                        testVertex.OClassName = "TestVertexClass";
+                        testVertex.SetField("foo", "foo string value");
+                        testVertex.SetField("bar", i);
+                        database.Transaction.Add(testVertex);
+                    }
+
+                    database.Transaction.Commit();
+
+
+                    var createdVertices = database.Select().From("V").ToList();
+                    Assert.AreEqual(1000, createdVertices.Count);
+
+                    for (int i = 0; i < 1000; i++)
+                    {
+                        Assert.AreEqual(i, createdVertices[i].GetField<int>("bar"));
+                    }
+
+                }
+            }
+        }
+
+
+        [Test]
+        public void TestCreateVerticesAndEdge()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database
+                        .Create.Class("TestVertexClass")
+                        .Extends<OVertex>()
+                        .Run();
+
+
+                    var testVertex1 = CreateTestVertex(1);
+                    var testVertex2 = CreateTestVertex(2);
+                    database.Transaction.Add(testVertex1);
+                    database.Transaction.Add(testVertex2);
+                    testVertex1.OutE.Add(testVertex2.ORID);
+                    testVertex2.InE.Add(testVertex1.ORID);
+
+
+                    database.Transaction.Commit();
+
+                    Assert.AreEqual(testVertex2.ORID, testVertex1.OutE.First());
+                    Assert.AreEqual(testVertex1.ORID, testVertex2.InE.First());
+
+                    var createdVertices = database.Select().From("V").ToList<OVertex>();
+                    Assert.AreEqual(2, createdVertices.Count);
+
+                    Assert.AreEqual(createdVertices[1].ORID, createdVertices[0].OutE.First());
+                    Assert.AreEqual(createdVertices[0].ORID, createdVertices[1].InE.First());
+
+                }
+            }
+        }
+
+        class Widget : OBaseRecord
+        {
+            public string Foo { get; set; }
+            public int Bar { get; set; }
+            public ORID OtherWidget { get; set; }
+        }
+
+        [Test]
+        public void TestTypedCreateVerticesAndLinks()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // prerequisites
+                    database.Create.Class<Widget>().Extends<OVertex>().Run();
+
+
+                    var w1 = new Widget() { Foo = "foo", Bar = 1 };
+                    var w2 = new Widget() { Foo = "woo", Bar = 2 };
+
+                    database.Transaction.Add(w1);
+                    database.Transaction.Add(w2);
+                    w1.OtherWidget = w2.ORID;
+
+                    database.Transaction.Commit();
+
+                    Assert.AreEqual(w2.ORID, w1.OtherWidget);
+
+                    var createdVertices = database.Select().From<Widget>().ToList<Widget>();
+                    Assert.AreEqual(2, createdVertices.Count);
+
+                    var withLink = createdVertices.First(x => x.OtherWidget != null);
+                    var noLink = createdVertices.First(x => x.OtherWidget == null);
+
+
+                    Assert.AreEqual(noLink.ORID, withLink.OtherWidget);
+
+                }
+            }
+        }
+
+        private static OVertex CreateTestVertex(int iBar)
+        {
+            OVertex testVertex = new OVertex();
+            testVertex.OClassName = "TestVertexClass";
+            testVertex.SetField("foo", "foo string value");
+            testVertex.SetField("bar", iBar);
+            return testVertex;
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Query/UpdateRecordTest.cs
+++ b/src/Orient/Orient.NUnit/Query/UpdateRecordTest.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class UpdateRecordTest
+    {
+        [Test]
+        public void ShouldUpdateRecord()
+        {
+            using (var testContext = new TestDatabaseContext())
+            using (var database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                // prerequisites
+                database
+                    .Create.Class("TestClass")
+                    .Run();
+
+                ODocument document = new ODocument { OClassName = "TestClass" }
+                    .SetField("foo", "foo string value")
+                    .SetField("bar", 12345);
+
+                var cd = database.Create.Document(document).Run();
+                cd.SetField("bar", 54321);
+
+                var ud = database.Update(cd).Run();
+                cd.SetField("bar", 9876);
+                var ud1 = database.Update(cd).Run();
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Serialization/RecordBinaryDeserializationTest.cs
+++ b/src/Orient/Orient.NUnit/Serialization/RecordBinaryDeserializationTest.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Text;
+using NUnit.Framework;
+using Orient.Client;
+using Orient.Client.Protocol.Serializers;
+
+namespace Orient.Tests.Serialization
+{
+    [TestFixture]
+    public class RecordBinaryDeserializationTest
+    {
+        private IRecordSerializer serializer;
+        TestDatabaseContext context;
+        ODatabase database;
+
+        [SetUp]
+        public void Init()
+        {
+            context = new TestDatabaseContext();
+            database = new ODatabase(TestConnection.GlobalTestDatabaseAlias);
+            serializer = RecordSerializerFactory.GetSerializer(database);
+
+            database
+                .Create
+                .Class("TestClass")
+                .Run();
+
+            database
+                .Create
+                .Property("_date", OType.Date)
+                .Class("TestClass")
+                .Run();
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            context.Dispose();
+            context = null;
+            database.Dispose();
+            database = null;
+        }
+
+        [Test]
+        [Ignore]
+        public void ShouldDeserializeWholeStructure()
+        {
+            /*
+                The whole record is structured in three main segments
+                +---------------+------------------+---------------+-------------+
+                | version:byte   | className:string | header:byte[] | data:byte[]  |
+                +---------------+------------------+---------------+-------------+
+             */
+
+
+            //byte version = 0;
+            byte[] className = Encoding.UTF8.GetBytes("TestClass");
+            byte[] header = new byte[0];
+            byte[] data = new byte[0];
+
+            //string serString = "ABJUZXN0Q2xhc3MpAAAAEQDI/wE=";
+            string serString1 = "AAxQZXJzb24EaWQAAABEBwhuYW1lAAAAaQcOc3VybmFtZQAAAHAHEGJpcnRoZGF5AAAAdwYQY2hpbGRyZW4AAAB9AQBIZjk1M2VjNmMtNGYyMC00NDlhLWE2ODQtYjQ2ODkxNmU4NmM3DEJpbGx5MQxNYXllczGUlfWVo1IC/wE=";
+
+            var document = new ODocument();
+            document.OClassName = "TestClass";
+            document.SetField<DateTime>("_date", DateTime.Now);
+
+            var createdDocument = database
+                .Create
+                .Document(document)
+                .Run();
+
+            Assert.AreEqual(document.GetField<DateTime>("_date").Date, createdDocument.GetField<DateTime>("eeee"));
+            var serBytes1 = Convert.FromBase64String(serString1);
+            var doc = serializer.Deserialize(serBytes1, new ODocument());
+        }
+
+        [Test]
+        [Ignore]
+        public void ShouldSerializeDocumnet()
+        {
+            //string serString = "ABJUZXN0Q2xhc3MpAAAAEQDI/wE=";
+            ODocument document = new ODocument();
+            document.OClassName = "TestClass";
+            document.SetField<DateTime>("eeee", new DateTime(635487552000000000));
+
+            var str = Convert.ToBase64String(serializer.Serialize(document));
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Serialization/RecordBinarySerializationTest.cs
+++ b/src/Orient/Orient.NUnit/Serialization/RecordBinarySerializationTest.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Text;
+using NUnit.Framework;
+using Orient.Client;
+using Orient.Client.API.Types;
+using Orient.Client.Protocol.Serializers;
+
+namespace Orient.Tests.Serialization
+{
+    [TestFixture]
+    public class RecordBinarySerializationTest
+    {
+        private IRecordSerializer serializer;
+        TestDatabaseContext context;
+        ODatabase database;
+
+        [SetUp]
+        public void Init()
+        {
+            context = new TestDatabaseContext();
+            database = new ODatabase(TestConnection.GlobalTestDatabaseAlias);
+            serializer = RecordSerializerFactory.GetSerializer(database);
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            context.Dispose();
+            context = null;
+            database.Dispose();
+            database = null;
+        }
+
+
+        [Test]
+        public void testSimpleSerialization()
+        {
+            var clusterid = database
+                .Create.Class("TestVertexClass")
+                .Extends<OVertex>()
+                .Run();
+
+            var datetime = DateTime.Now;
+            datetime = datetime.AddTicks(-(datetime.Ticks % TimeSpan.TicksPerSecond)); // ORIENTDB not count milliseconds
+
+            OVertex createdVertex = database
+                .Create.Vertex("TestVertexClass")
+                .Set("foo", "foo string value")
+                .Set("bar", 12345)
+                .Set("_long", 1234566L)
+                .Set("_short", (short)12)
+                .Set("_float", 2.54f)
+                .Set<Double>("_double", 1000234D)
+                .Set<DateTime>("_datetime", datetime)
+                //.Set<decimal>("_decimal", (decimal)10234.546) // Some problem with decimal not sure if this is a bug in product
+                .Run();
+
+            var loadedVertex = database.Load.ORID(createdVertex.ORID).Run();
+            Assert.IsNotNull(loadedVertex);
+            Assert.AreEqual("TestVertexClass", loadedVertex.OClassName);
+            Assert.AreEqual("foo string value", loadedVertex.GetField<string>("foo"));
+            Assert.AreEqual(12345, loadedVertex.GetField<int>("bar"));
+            Assert.AreEqual(1234566L, loadedVertex.GetField<long>("_long"));
+            Assert.AreEqual(12, loadedVertex.GetField<short>("_short"));
+            Assert.AreEqual(2.54f, loadedVertex.GetField<float>("_float"));
+            Assert.AreEqual(1000234D, loadedVertex.GetField<double>("_double"));
+            Assert.AreEqual(datetime, loadedVertex.GetField<DateTime>("_datetime"));
+
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Serialization/RecordDeserializationTests.cs
+++ b/src/Orient/Orient.NUnit/Serialization/RecordDeserializationTests.cs
@@ -1,0 +1,708 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+using Orient.Client;
+using Orient.Client.API.Types;
+using Orient.Client.Mapping;
+using Orient.Client.Protocol.Serializers;
+
+namespace Orient.Tests.Serialization
+{
+    [TestFixture]
+    public class RecordDeserializationTests
+    {
+        private IRecordSerializer serializer;
+        [SetUp]
+        public void Init()
+        {
+            serializer = RecordSerializerFactory.GetSerializer(ORecordFormat.ORecordDocument2csv);
+        }
+        [Test]
+        public void ShouldDeserializeDocSimpleExample()
+        {
+            string recordString = "Profile@nick:\"ThePresident\",follows:[],followers:[#10:5,#10:6],name:\"Barack\",surname:\"Obama\",location:#3:2,invitedBy:,salary_cloned:,salary:120.3f";
+            var rawDocument = Encoding.UTF8.GetBytes(recordString);
+            //ODocument document = ODocument.Deserialize(recordString);
+            ODocument document = serializer.Deserialize(rawDocument, new ODocument());
+
+            Assert.AreEqual(document.OClassName, "Profile");
+
+            // check for fields existence
+            Assert.AreEqual(document.HasField("nick"), true);
+            Assert.AreEqual(document.HasField("follows"), true);
+            Assert.AreEqual(document.HasField("followers"), true);
+            Assert.AreEqual(document.HasField("name"), true);
+            Assert.AreEqual(document.HasField("surname"), true);
+            Assert.AreEqual(document.HasField("location"), true);
+            Assert.AreEqual(document.HasField("invitedBy"), true);
+            Assert.AreEqual(document.HasField("salary_cloned"), true);
+            Assert.AreEqual(document.HasField("salary"), true);
+
+            // check for fields values
+            Assert.AreEqual(document.GetField<string>("nick"), "ThePresident");
+
+            Assert.AreEqual(document.GetField<List<object>>("follows").Count, new List<object>().Count);
+
+
+            List<ORID> recordFollowers = document.GetField<List<ORID>>("followers");
+            List<ORID> followers = new List<ORID> { new ORID("#10:5"), new ORID("#10:6") };
+
+            Assert.AreEqual(recordFollowers.Count, followers.Count);
+            Assert.AreEqual(recordFollowers[0], followers[0]);
+            Assert.AreEqual(recordFollowers[1], followers[1]);
+
+            Assert.AreEqual(document.GetField<string>("name"), "Barack");
+            Assert.AreEqual(document.GetField<string>("surname"), "Obama");
+            Assert.AreEqual(document.GetField<ORID>("location"), new ORID("#3:2"));
+            Assert.AreEqual(document.GetField<string>("invitedBy"), null);
+            Assert.AreEqual(document.GetField<string>("salary_cloned"), null);
+            Assert.AreEqual(document.GetField<float>("salary"), 120.3f);
+        }
+
+        [Test]
+        public void ShouldDeserializeDocComplexExample()
+        {
+            string recordString =
+                "name:\"ORole\"," +
+                "id:0," +
+                "defaultClusterId:3," +
+                "clusterIds:[3]," +
+                "properties:[" +
+                    "(name:\"mode\",type:17,offset:0,mandatory:false,notNull:false,min:,max:,linkedClass:,linkedType:,index:)," +
+                    "(name:\"rules\",type:12,offset:1,mandatory:false,notNull:false,min:,max:,linkedClass:,linkedType:17,index:)" +
+                "]";
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            // check for fields existence
+            Assert.AreEqual(document.HasField("name"), true);
+            Assert.AreEqual(document.HasField("id"), true);
+            Assert.AreEqual(document.HasField("defaultClusterId"), true);
+            Assert.AreEqual(document.HasField("clusterIds"), true);
+            Assert.AreEqual(document.HasField("properties"), true);
+
+            // check for fields values
+            Assert.AreEqual(document.GetField<string>("name"), "ORole");
+            Assert.AreEqual(document.GetField<int>("id"), 0);
+            Assert.AreEqual(document.GetField<int>("defaultClusterId"), 3);
+            Assert.AreEqual(document.GetField<List<int>>("clusterIds").Count, 1);
+            Assert.AreEqual(document.GetField<List<int>>("clusterIds")[0], 3);
+
+            List<DocComplexExampleEmbedded> loadedProperties = document.GetField<List<DocComplexExampleEmbedded>>("properties");
+            List<DocComplexExampleEmbedded> properties = new List<DocComplexExampleEmbedded>();
+            properties.Add(new DocComplexExampleEmbedded() { name = "mode", type = 17, offset = 0, mandatory = false, notNull = false, min = null, max = null, linkedClass = null, linkedType = null, index = null });
+            properties.Add(new DocComplexExampleEmbedded() { name = "rules", type = 12, offset = 1, mandatory = false, notNull = false, min = null, max = null, linkedClass = null, linkedType = 17, index = null });
+
+            Assert.AreEqual(loadedProperties.Count, properties.Count);
+
+            for (int i = 0; i < loadedProperties.Count; i++)
+            {
+                Assert.AreEqual(loadedProperties[i].name, properties[i].name);
+                Assert.AreEqual(loadedProperties[i].type, properties[i].type);
+                Assert.AreEqual(loadedProperties[i].offset, properties[i].offset);
+                Assert.AreEqual(loadedProperties[i].mandatory, properties[i].mandatory);
+                Assert.AreEqual(loadedProperties[i].notNull, properties[i].notNull);
+                Assert.AreEqual(loadedProperties[i].min, properties[i].min);
+                Assert.AreEqual(loadedProperties[i].max, properties[i].max);
+                Assert.AreEqual(loadedProperties[i].linkedClass, properties[i].linkedClass);
+                Assert.AreEqual(loadedProperties[i].linkedType, properties[i].linkedType);
+                Assert.AreEqual(loadedProperties[i].index, properties[i].index);
+            }
+        }
+
+        [Test]
+        public void ShouldDeserializeDocBinary()
+        {
+            string recordString = "single:_AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGx_,embedded:(binary:_AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGx_),array:[_AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGx_,_AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGx_]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            // check for fields existence
+            Assert.AreEqual(document.HasField("single"), true);
+            Assert.AreEqual(document.HasField("embedded"), true);
+            Assert.AreEqual(document.HasField("embedded.binary"), true);
+            Assert.AreEqual(document.HasField("array"), true);
+
+            // check for fields values
+            Assert.AreEqual(document.GetField<byte[]>("single").GetType(), typeof(byte[]));
+            Assert.AreEqual(document.GetField<byte[]>("embedded.binary").GetType(), typeof(byte[]));
+
+            List<byte[]> array = document.GetField<List<byte[]>>("array");
+            Assert.AreEqual(array.Count, 2);
+            Assert.AreEqual(array[0].GetType(), typeof(byte[]));
+            Assert.AreEqual(array[0].GetType(), typeof(byte[]));
+        }
+
+        [Test]
+        public void ShouldDeserializeDateTime()
+        {
+            string recordString = "datetime:1296279468000t,date:1306281600000a,embedded:(datetime:1296279468000t,date:1306281600000a),array:[1296279468000t,1306281600000a]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            // check for fields existence
+            Assert.AreEqual(document.HasField("datetime"), true);
+            Assert.AreEqual(document.HasField("date"), true);
+            Assert.AreEqual(document.HasField("embedded.datetime"), true);
+            Assert.AreEqual(document.HasField("embedded.date"), true);
+            Assert.AreEqual(document.HasField("array"), true);
+
+            // check for fields values
+            Assert.AreEqual(document.GetField<DateTime>("datetime"), new DateTime(2011, 1, 29, 5, 37, 48));
+            Assert.AreEqual(document.GetField<DateTime>("date"), new DateTime(2011, 5, 25, 0, 0, 0));
+            Assert.AreEqual(document.GetField<DateTime>("embedded.datetime"), new DateTime(2011, 1, 29, 5, 37, 48));
+            Assert.AreEqual(document.GetField<DateTime>("embedded.date"), new DateTime(2011, 5, 25, 0, 0, 0));
+
+            List<DateTime> array = document.GetField<List<DateTime>>("array");
+            Assert.AreEqual(array.Count, 2);
+            Assert.AreEqual(array[0], new DateTime(2011, 1, 29, 5, 37, 48));
+            Assert.AreEqual(array[1], new DateTime(2011, 5, 25, 0, 0, 0));
+        }
+
+        [Test]
+        public void ShouldDeserializeBoolean()
+        {
+            string recordString = "singleT:true,singleF:false,embedded:(singleT:true,singleF:false),array:[true,false]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            // check for fields existence
+            Assert.AreEqual(document.HasField("singleT"), true);
+            Assert.AreEqual(document.HasField("singleF"), true);
+            Assert.AreEqual(document.HasField("embedded.singleT"), true);
+            Assert.AreEqual(document.HasField("embedded.singleF"), true);
+            Assert.AreEqual(document.HasField("array"), true);
+
+            // check for fields values
+            Assert.AreEqual(document.GetField<bool>("singleT"), true);
+            Assert.AreEqual(document.GetField<bool>("singleF"), false);
+            Assert.AreEqual(document.GetField<bool>("embedded.singleT"), true);
+            Assert.AreEqual(document.GetField<bool>("embedded.singleF"), false);
+
+            List<bool> array = document.GetField<List<bool>>("array");
+            Assert.AreEqual(array.Count, 2);
+            Assert.AreEqual(array[0], true);
+            Assert.AreEqual(array[1], false);
+        }
+
+        [Test]
+        public void ShouldDeserializeNull()
+        {
+            string recordString = "nick:,embedded:(nick:,joe:),joe:";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            // check for fields existence
+            Assert.AreEqual(document.HasField("nick"), true);
+            Assert.AreEqual(document.HasField("embedded.nick"), true);
+            Assert.AreEqual(document.HasField("embedded.joe"), true);
+            Assert.AreEqual(document.HasField("joe"), true);
+
+            // check for fields values
+            Assert.AreEqual(document.GetField<string>("nick"), null);
+            Assert.AreEqual(document.GetField<string>("embedded.nick"), null);
+            Assert.AreEqual(document.GetField<string>("embedded.joe"), null);
+            Assert.AreEqual(document.GetField<string>("joe"), null);
+        }
+
+        [Test]
+        public void ShouldDeserializeNumbers()
+        {
+            string recordString = "byte:123b,short:23456s,int:1543345,long:13243432455l,float:1234.432f,double:123123.4324d,bigdecimal:300.5c,embedded:(byte:123b,short:23456s,int:1543345,long:13243432455l,float:1234.432f,double:123123.4324d,bigdecimal:300.5c),array:[123b,23456s,1543345,13243432455l,1234.432f,123123.4324d,300.5c]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            // check for fields existence
+            Assert.AreEqual(document.HasField("byte"), true);
+            Assert.AreEqual(document.HasField("short"), true);
+            Assert.AreEqual(document.HasField("int"), true);
+            Assert.AreEqual(document.HasField("long"), true);
+            Assert.AreEqual(document.HasField("float"), true);
+            Assert.AreEqual(document.HasField("double"), true);
+            Assert.AreEqual(document.HasField("bigdecimal"), true);
+            Assert.AreEqual(document.HasField("embedded.byte"), true);
+            Assert.AreEqual(document.HasField("embedded.short"), true);
+            Assert.AreEqual(document.HasField("embedded.int"), true);
+            Assert.AreEqual(document.HasField("embedded.long"), true);
+            Assert.AreEqual(document.HasField("embedded.float"), true);
+            Assert.AreEqual(document.HasField("embedded.double"), true);
+            Assert.AreEqual(document.HasField("embedded.bigdecimal"), true);
+            Assert.AreEqual(document.HasField("array"), true);
+
+            // check for fields values
+            Assert.AreEqual(document.GetField<byte>("byte"), (byte)123);
+            Assert.AreEqual(document.GetField<short>("short"), (short)23456);
+            Assert.AreEqual(document.GetField<int>("int"), 1543345);
+            Assert.AreEqual(document.GetField<long>("long"), 13243432455);
+            Assert.AreEqual(document.GetField<float>("float"), 1234.432f);
+            Assert.AreEqual(document.GetField<double>("double"), 123123.4324);
+            Assert.AreEqual(document.GetField<decimal>("bigdecimal"), 300.5m);
+            Assert.AreEqual(document.GetField<byte>("embedded.byte"), (byte)123);
+            Assert.AreEqual(document.GetField<short>("embedded.short"), (short)23456);
+            Assert.AreEqual(document.GetField<int>("embedded.int"), 1543345);
+            Assert.AreEqual(document.GetField<long>("embedded.long"), 13243432455);
+            Assert.AreEqual(document.GetField<float>("embedded.float"), 1234.432f);
+            Assert.AreEqual(document.GetField<double>("embedded.double"), 123123.4324);
+            Assert.AreEqual(document.GetField<decimal>("embedded.bigdecimal"), 300.5m);
+
+            List<object> array = document.GetField<List<object>>("array");
+            Assert.AreEqual(array.Count, 7);
+            Assert.AreEqual(array[0], (byte)123);
+            Assert.AreEqual(array[1], (short)23456);
+            Assert.AreEqual(array[2], 1543345);
+            Assert.AreEqual(array[3], 13243432455);
+            Assert.AreEqual(array[4], 1234.432f);
+            Assert.AreEqual(array[5], 123123.4324);
+            Assert.AreEqual(array[6], 300.5m);
+        }
+
+        [Test]
+        public void ShouldDeserializeString()
+        {
+            string recordString = "simple:\"whoa this is awesome\",singleQuoted:\"a" + "\\" + "\"\",doubleQuoted:\"" + "\\" + "\"adsf" + "\\" + "\"\",twoBackslashes:\"" + "\\a" + "\\a" + "\"";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            // check for fields existence
+            Assert.AreEqual(document.HasField("simple"), true);
+            Assert.AreEqual(document.HasField("singleQuoted"), true);
+            Assert.AreEqual(document.HasField("doubleQuoted"), true);
+            Assert.AreEqual(document.HasField("twoBackslashes"), true);
+
+            // check for fields values
+            Assert.AreEqual(document.GetField<string>("simple"), "whoa this is awesome");
+            Assert.AreEqual(document.GetField<string>("singleQuoted"), "a\"");
+            Assert.AreEqual(document.GetField<string>("doubleQuoted"), "\"adsf\"");
+            Assert.AreEqual(document.GetField<string>("twoBackslashes"), "\\a\\a");
+        }
+
+        [Test]
+        public void ShouldDeserializeSimpleEmbeddedrecordsArray()
+        {
+            string recordString = "array:[(joe1:\"js1\"),(joe2:\"js2\"),(joe3:\"js3\")]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            // check for fields existence
+            Assert.AreEqual(document.HasField("array"), true);
+
+            // check for fields values
+            List<ODocument> array = document.GetField<List<ODocument>>("array");
+            Assert.AreEqual(array.Count, 3);
+            Assert.AreEqual(array[0].GetField<string>("joe1"), "js1");
+            Assert.AreEqual(array[1].GetField<string>("joe2"), "js2");
+            Assert.AreEqual(array[2].GetField<string>("joe3"), "js3");
+        }
+
+        [Test]
+        public void ShouldDeserializeComplexEmbeddedrecordsArray()
+        {
+            string recordString = "array:[(zak1:(nick:[(joe1:\"js1\"),(joe2:\"js2\"),(joe3:\"js3\")])),(zak2:(nick:[(joe4:\"js4\"),(joe5:\"js5\"),(joe6:\"js6\")]))]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            // check for fields existence
+            Assert.AreEqual(document.HasField("array"), true);
+
+            // check for fields values
+            List<ODocument> arrayOfZaks = document.GetField<List<ODocument>>("array");
+            Assert.AreEqual(arrayOfZaks.Count, 2);
+
+            List<ODocument> arrayOfJoes1 = arrayOfZaks[0].GetField<List<ODocument>>("zak1.nick");
+            Assert.AreEqual(arrayOfJoes1.Count, 3);
+            Assert.AreEqual(arrayOfJoes1[0].GetField<string>("joe1"), "js1");
+            Assert.AreEqual(arrayOfJoes1[1].GetField<string>("joe2"), "js2");
+            Assert.AreEqual(arrayOfJoes1[2].GetField<string>("joe3"), "js3");
+
+            List<ODocument> arrayOfJoes2 = arrayOfZaks[1].GetField<List<ODocument>>("zak2.nick");
+            Assert.AreEqual(arrayOfJoes2.Count, 3);
+            Assert.AreEqual(arrayOfJoes2[0].GetField<string>("joe4"), "js4");
+            Assert.AreEqual(arrayOfJoes2[1].GetField<string>("joe5"), "js5");
+            Assert.AreEqual(arrayOfJoes2[2].GetField<string>("joe6"), "js6");
+        }
+
+        [Test]
+        public void ShouldDeserializeSingleAndListOfOrids()
+        {
+            string recordString = "single:#10:12345,list:[#11:123,#22:1234,#33:1234567]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            // check for fields existence
+            Assert.AreEqual(document.HasField("single"), true);
+            Assert.AreEqual(document.HasField("list"), true);
+
+            // check for fields values
+            Assert.AreEqual(document.GetField<ORID>("single"), new ORID(10, 12345));
+            List<ORID> collection = document.GetField<List<ORID>>("list");
+            Assert.AreEqual(collection.Count, 3);
+            Assert.AreEqual(collection[0], new ORID(11, 123));
+            Assert.AreEqual(collection[1], new ORID(22, 1234));
+            Assert.AreEqual(collection[2], new ORID(33, 1234567));
+        }
+
+        [Test]
+        public void ShouldDeserializeSingleItemToOneElementList()
+        {
+            string recordString = "single:#10:12345,list:[#11:123,#22:1234,#33:1234567]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            // check for fields existence
+            Assert.AreEqual(document.HasField("single"), true);
+            Assert.AreEqual(document.HasField("list"), true);
+
+            // check for fields values
+            List<ORID> collection = document.GetField<List<ORID>>("single");
+            Assert.AreEqual(collection.Count, 1);
+            Assert.AreEqual(collection[0], new ORID(10, 12345));
+        }
+
+        class TestObject
+        {
+            public int Value { get; set; }
+            public string Text { get; set; }
+            public ORID Link { get; set; }
+            public List<ORID> single { get; set; }
+            public List<ORID> list { get; set; }
+
+            public ORID ORID { get; set; }
+        }
+
+        [Test]
+        public void ShouldDeserializeSingleItemToOneElementListFieldOfObject()
+        {
+            // important if you use ordered edges, since if more than 1 they appear as a list, if only one then as a single object, ie
+            //    db.Create.Class<Person>().Extends("V").Run();
+            //    db.Command("create property Person.in_FriendOf ANY");
+            //    db.Command("alter property Person.in_FriendOf custom ordered=true");
+
+            string recordString = "single:#10:12345,list:[#11:123,#22:1234,#33:1234567],ORID:#10:123,Link:#10:234,Value:17";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            // check for fields existence
+            Assert.AreEqual(document.HasField("single"), true);
+            Assert.AreEqual(document.HasField("list"), true);
+
+            var testObj = document.To<TestObject>();
+            Assert.IsNotNull(testObj);
+            Assert.IsNotNull(testObj.single);
+            Assert.IsNotNull(testObj.list);
+            Assert.AreEqual(1, testObj.single.Count);
+            Assert.AreEqual(3, testObj.list.Count);
+        }
+
+        [Test]
+        public void ShouldDeserializeSingleItemToOneElementListFieldOfObjectViaDB()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    // important if you use ordered edges, since if more than 1 they appear as a list, if only one then as a single object, ie
+                    //    db.Create.Class<Person>().Extends("V").Run();
+                    //    db.Command("create property Person.in_FriendOf ANY");
+                    //    db.Command("alter property Person.in_FriendOf custom ordered=true");
+
+                    string recordString = "single:#10:12345,list:[#11:123,#22:1234,#33:1234567],ORID:#10:123,Link:#10:234,Value:17";
+
+                    var rawRecord = Encoding.UTF8.GetBytes(recordString);
+                    ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+                    var vertex = database.Create.Vertex("V").Set(document).Run();
+
+                    var loaded = database.Load.ORID(vertex.ORID).Run();
+
+
+                    var testObj = loaded.To<TestObject>();
+
+                    Assert.IsNotNull(testObj);
+                    Assert.IsNotNull(testObj.single);
+                    Assert.IsNotNull(testObj.list);
+                    Assert.IsNotNull(testObj.ORID);
+                    Assert.IsNotNull(testObj.Link);
+                    Assert.AreEqual(1, testObj.single.Count);
+                    Assert.AreEqual(3, testObj.list.Count);
+                }
+            }
+        }
+
+        class TestArray
+        {
+            public int[] values { get; set; }
+        }
+
+        class TestList
+        {
+            public List<int> values { get; set; }
+        }
+
+        [Test]
+        public void TestDeserializeArray()
+        {
+            string recordString = "values:[1,2,3,4,5]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            TypeMapper<TestArray> tm = TypeMapper<TestArray>.Instance;
+            var t = new TestArray();
+            tm.ToObject(document, t);
+
+            Assert.IsNotNull(t.values);
+            Assert.AreEqual(5, t.values.Length);
+            Assert.AreEqual(3, t.values[2]);
+
+        }
+
+        [Test]
+        public void TestDeserializeList()
+        {
+            string recordString = "values:[1,2,3,4,5]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            TypeMapper<TestList> tm = TypeMapper<TestList>.Instance;
+            var t = new TestList();
+            tm.ToObject(document, t);
+
+            Assert.IsNotNull(t.values);
+            Assert.AreEqual(5, t.values.Count);
+            Assert.AreEqual(3, t.values[2]);
+
+        }
+
+        class Thing
+        {
+            public int Value { get; set; }
+            public string Text { get; set; }
+        }
+
+        class TestHasAThing
+        {
+            public Thing TheThing { get; set; }
+        }
+
+        [Test]
+        public void TestDeserializeSubObject()
+        {
+            string recordString = "TheThing:(Value:17,Text:\"blah\")";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            TypeMapper<TestHasAThing> tm = TypeMapper<TestHasAThing>.Instance;
+            var t = new TestHasAThing();
+            tm.ToObject(document, t);
+
+            Assert.IsNotNull(t.TheThing);
+            Assert.AreEqual(17, t.TheThing.Value);
+            Assert.AreEqual("blah", t.TheThing.Text);
+
+        }
+
+        class TestHasThings
+        {
+            public Thing[] TheThings { get; set; }
+        }
+
+        [Test]
+        public void TestDeserializeSubObjectArray()
+        {
+            string recordString = "TheThings:[(Value:17,Text:\"blah\"),(Value:18,Text:\"foo\")]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            TypeMapper<TestHasThings> tm = TypeMapper<TestHasThings>.Instance;
+            var t = new TestHasThings();
+            tm.ToObject(document, t);
+
+            Assert.IsNotNull(t.TheThings);
+            Assert.AreEqual(2, t.TheThings.Length);
+            Assert.AreEqual(18, t.TheThings[1].Value);
+            Assert.AreEqual("foo", t.TheThings[1].Text);
+
+        }
+
+        [Test]
+        public void TestDeserializeSingleSubObjectArray()
+        {
+            string recordString = "TheThings:[(Value:18,Text:\"foo\")]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            TypeMapper<TestHasThings> tm = TypeMapper<TestHasThings>.Instance;
+            var t = new TestHasThings();
+            tm.ToObject(document, t);
+
+            Assert.IsNotNull(t.TheThings);
+            Assert.AreEqual(1, t.TheThings.Length);
+            Assert.AreEqual(18, t.TheThings[0].Value);
+            Assert.AreEqual("foo", t.TheThings[0].Text);
+
+        }
+
+        [Test]
+        public void TestDeserializeEmptySubObjectArray()
+        {
+            string recordString = "TheThings:[]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            TypeMapper<TestHasThings> tm = TypeMapper<TestHasThings>.Instance;
+            var t = new TestHasThings();
+            tm.ToObject(document, t);
+
+            Assert.IsNotNull(t.TheThings, "much easier for consumers to have a consistent behaviour - collections always created but empty, rather than having to test for nullness");
+            Assert.AreEqual(0, t.TheThings.Length);
+
+        }
+
+        class TestHasListThings
+        {
+            public List<Thing> TheThings { get; set; }
+        }
+
+        [Test]
+        public void TestDeserializeSubObjectList()
+        {
+            string recordString = "TheThings:[(Value:17,Text:\"blah\"),(Value:18,Text:\"foo\")]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            TypeMapper<TestHasListThings> tm = TypeMapper<TestHasListThings>.Instance;
+            var t = new TestHasListThings();
+            tm.ToObject(document, t);
+
+            Assert.IsNotNull(t.TheThings);
+            Assert.AreEqual(2, t.TheThings.Count);
+            Assert.AreEqual(18, t.TheThings[1].Value);
+            Assert.AreEqual("foo", t.TheThings[1].Text);
+
+        }
+
+        [Test]
+        public void TestDeserializeSingleSubObjectList()
+        {
+            string recordString = "TheThings:[(Value:18,Text:\"foo\")]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            TypeMapper<TestHasListThings> tm = TypeMapper<TestHasListThings>.Instance;
+            var t = new TestHasListThings();
+            tm.ToObject(document, t);
+
+            Assert.IsNotNull(t.TheThings);
+            Assert.AreEqual(1, t.TheThings.Count);
+
+        }
+
+
+        [Test]
+        public void TestDeserializationMapping()
+        {
+            // important if you use ordered edges, since if more than 1 they appear as a list, if only one then as a single object, ie
+            //    db.Create.Class<Person>().Extends("V").Run();
+            //    db.Command("create property Person.in_FriendOf ANY");
+            //    db.Command("alter property Person.in_FriendOf custom ordered=true");
+
+            string recordString = "single:#10:12345,list:[#11:123,#22:1234,#33:1234567],Link:#11:123,Value:17,Text:\"some text\"";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument()); 
+            
+            document.ORID = new ORID("#123:45");
+            Assert.AreEqual(document.HasField("single"), true);
+            Assert.AreEqual(document.HasField("Link"), true);
+            Assert.AreEqual(document.HasField("Value"), true);
+            Assert.AreEqual(document.HasField("Text"), true);
+
+
+            TypeMapper<TestObject> tm = TypeMapper<TestObject>.Instance;
+            var testObj = new TestObject();
+            tm.ToObject(document, testObj);
+
+            Assert.AreEqual("#123:45", testObj.ORID.RID);
+
+            Assert.AreEqual(17, testObj.Value);
+            Assert.AreEqual("some text", testObj.Text);
+            Assert.IsNotNull(testObj.Link);
+            Assert.AreEqual("#11:123", testObj.Link.RID);
+            Assert.IsNotNull(testObj);
+            Assert.IsNotNull(testObj.single);
+            Assert.IsNotNull(testObj.list);
+            Assert.AreEqual(1, testObj.single.Count);
+            Assert.AreEqual(3, testObj.list.Count);
+        }
+
+        [Test]
+        public void ShouldDeserializeSingleAndSetOfOrids()
+        {
+            string recordString = "single:#10:12345,set:<#11:123,#22:1234,#33:1234567>,singleSet:<#44:44>";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            // check for fields existence
+            Assert.AreEqual(document.HasField("single"), true);
+            Assert.AreEqual(document.HasField("set"), true);
+
+            // check for fields values
+            Assert.AreEqual(document.GetField<ORID>("single"), new ORID(10, 12345));
+            HashSet<ORID> collection = document.GetField<HashSet<ORID>>("set");
+            Assert.AreEqual(collection.Count, 3);
+            Assert.IsTrue(collection.Contains(new ORID(11, 123)));
+            Assert.IsTrue(collection.Contains(new ORID(22, 1234)));
+            Assert.IsTrue(collection.Contains(new ORID(33, 1234567)));
+
+            HashSet<ORID> singleSet = document.GetField<HashSet<ORID>>("singleSet");
+            Assert.AreEqual(singleSet.Count, 1);
+            Assert.IsTrue(singleSet.Contains(new ORID(44, 44)));
+        }
+
+        /*[Test]
+        public void ShouldDeserializeMapExample()
+        {
+            string recordString = "ORole@name:\"reader\",inheritedRole:,mode:0,rules:{\"database\":2,\"database.cluster.internal\":2,\"database.cluster.orole\":2,\"database.cluster.ouser\":2,\"database.class.*\":2,\"database.cluster.*\":2,\"database.query\":2,\"database.command\":2,\"database.hook.record\":2}";
+
+            ODocument document = ODocument.Deserialize(recordString);
+
+            // check for fields existence
+
+            // check for fields values
+        }*/
+    }
+
+    class DocComplexExampleEmbedded
+    {
+        public string name { get; set; }
+        public int type { get; set; }
+        public int offset { get; set; }
+        public bool mandatory { get; set; }
+        public bool notNull { get; set; }
+        public int? min { get; set; }
+        public int? max { get; set; }
+        public object linkedClass { get; set; }
+        public int? linkedType { get; set; }
+        public int? index { get; set; }
+    }
+}

--- a/src/Orient/Orient.NUnit/Serialization/RecordDocumentSerializationTests.cs
+++ b/src/Orient/Orient.NUnit/Serialization/RecordDocumentSerializationTests.cs
@@ -1,0 +1,355 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Orient.Client;
+using Orient.Client.API.Types;
+using Orient.Client.Mapping;
+using Orient.Client.Protocol.Serializers;
+
+namespace Orient.Tests.Serialization
+{
+    [TestFixture]
+    public class RecordDocumentSerializationTests
+    {
+        private IRecordSerializer serializer;
+        [SetUp]
+        public void Init()
+        {
+            serializer = RecordSerializerFactory.GetSerializer(ORecordFormat.ORecordDocument2csv);
+        }
+
+        [Test]
+        public void ShouldParseClassToDocument()
+        {
+            TestProfileClass profile = new TestProfileClass();
+            profile.ORID = new ORID(8, 0);
+            profile.OVersion = 1;
+            profile.OClassId = 8;
+            profile.Name = "Johny";
+            profile.Surname = "Bravo";
+
+            ODocument document = profile.ToDocument();
+
+            Assert.AreEqual(document.ORID, profile.ORID);
+            Assert.AreEqual(document.OVersion, profile.OVersion);
+            Assert.AreEqual(document.OClassId, profile.OClassId);
+            Assert.AreEqual(document.OClassName, typeof(TestProfileClass).Name);
+
+            Assert.AreEqual(document.GetField<string>("Name"), profile.Name);
+            Assert.AreEqual(document.GetField<string>("Surname"), profile.Surname);
+        }
+
+        [Test]
+        public void ShouldParseClassToDocumentWithExplicitOClassName()
+        {
+            TestProfileClass profile = new TestProfileClass();
+            profile.ORID = new ORID(8, 0);
+            profile.OVersion = 1;
+            profile.OClassId = 8;
+            profile.OClassName = "OtherProfileClass";
+            profile.Name = "Johny";
+            profile.Surname = "Bravo";
+
+            ODocument document = profile.ToDocument();
+
+            Assert.AreEqual(document.ORID, profile.ORID);
+            Assert.AreEqual(document.OVersion, profile.OVersion);
+            Assert.AreEqual(document.OClassId, profile.OClassId);
+            Assert.AreEqual(document.OClassName, "OtherProfileClass");
+
+            Assert.AreEqual(document.GetField<string>("Name"), profile.Name);
+            Assert.AreEqual(document.GetField<string>("Surname"), profile.Surname);
+        }
+
+        class TestArray
+        {
+            public int[] values { get; set; }
+        }
+
+        class TestList
+        {
+            public List<int> values { get; set; }
+        }
+
+        [Test]
+        public void TestSerializeArray()
+        {
+            string recordString = "TestArray@values:[1,2,3,4,5]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            TypeMapper<TestArray> tm = TypeMapper<TestArray>.Instance;
+            var t = new TestArray();
+            tm.ToObject(document, t);
+
+            Assert.IsNotNull(t.values);
+            Assert.AreEqual(5, t.values.Length);
+            Assert.AreEqual(3, t.values[2]);
+
+            ODocument newODocument = ODocument.ToDocument(t);
+            var serialized = Encoding.UTF8.GetString(serializer.Serialize(newODocument));
+            Assert.AreEqual(recordString, serialized);
+        }
+
+        [Test]
+        public void TestSerializeList()
+        {
+            string recordString = "TestList@values:[1,2,3,4,5]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+
+            TypeMapper<TestList> tm = TypeMapper<TestList>.Instance;
+            var t = new TestList();
+            tm.ToObject(document, t);
+
+            Assert.IsNotNull(t.values);
+            Assert.AreEqual(5, t.values.Count);
+            Assert.AreEqual(3, t.values[2]);
+
+            ODocument newODocument = ODocument.ToDocument(t);
+            var serialized = Encoding.UTF8.GetString(serializer.Serialize(newODocument));
+            Assert.AreEqual(recordString, serialized);
+        }
+
+        class Thing
+        {
+            public int Value { get; set; }
+            public string Text { get; set; }
+        }
+
+        class TestHasAThing
+        {
+            public Thing TheThing { get; set; }
+        }
+
+        [Test]
+        public void TestSerializeSubObject()
+        {
+            string recordString = "TestHasAThing@TheThing:(Value:17,Text:\"blah\")";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+
+            TypeMapper<TestHasAThing> tm = TypeMapper<TestHasAThing>.Instance;
+            var t = new TestHasAThing();
+            tm.ToObject(document, t);
+
+            Assert.IsNotNull(t.TheThing);
+            Assert.AreEqual(17, t.TheThing.Value);
+            Assert.AreEqual("blah", t.TheThing.Text);
+
+            ODocument newODocument = ODocument.ToDocument(t);
+            var serialized = Encoding.UTF8.GetString(serializer.Serialize(newODocument));
+            Assert.AreEqual(recordString, serialized);
+
+        }
+
+        class TestHasThings
+        {
+            public Thing[] TheThings { get; set; }
+        }
+
+        [Test]
+        public void TestSerializeSubObjectArray()
+        {
+            string recordString = "TestHasThings@TheThings:[(Value:17,Text:\"blah\"),(Value:18,Text:\"foo\")]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+
+            TypeMapper<TestHasThings> tm = TypeMapper<TestHasThings>.Instance;
+            var t = new TestHasThings();
+            tm.ToObject(document, t);
+
+            Assert.IsNotNull(t.TheThings);
+            Assert.AreEqual(2, t.TheThings.Length);
+            Assert.AreEqual(18, t.TheThings[1].Value);
+            Assert.AreEqual("foo", t.TheThings[1].Text);
+
+            ODocument newODocument = ODocument.ToDocument(t);
+            var serialized = Encoding.UTF8.GetString(serializer.Serialize(newODocument));
+            Assert.AreEqual(recordString, serialized);
+        }
+
+        [Test]
+        public void TestSerializeSingleSubObjectArray()
+        {
+            string recordString = "TestHasThings@TheThings:[(Value:18,Text:\"foo\")]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            TypeMapper<TestHasThings> tm = TypeMapper<TestHasThings>.Instance;
+            var t = new TestHasThings();
+            tm.ToObject(document, t);
+
+            Assert.IsNotNull(t.TheThings);
+            Assert.AreEqual(1, t.TheThings.Length);
+            Assert.AreEqual(18, t.TheThings[0].Value);
+            Assert.AreEqual("foo", t.TheThings[0].Text);
+
+            ODocument newODocument = ODocument.ToDocument(t);
+            var serialized = Encoding.UTF8.GetString(serializer.Serialize(newODocument));
+            Assert.AreEqual(recordString, serialized);
+        }
+
+        [Test]
+        public void TestSerializeEmptySubObjectArray()
+        {
+            string recordString = "TestHasThings@TheThings:[]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            TypeMapper<TestHasThings> tm = TypeMapper<TestHasThings>.Instance;
+            var t = new TestHasThings();
+            tm.ToObject(document, t);
+
+            Assert.IsNotNull(t.TheThings, "much easier for consumers to have a consistent behaviour - collections always created but empty, rather than having to test for nullness");
+            Assert.AreEqual(0, t.TheThings.Length);
+
+            ODocument newODocument = ODocument.ToDocument(t);
+            var serialized = Encoding.UTF8.GetString(serializer.Serialize(newODocument));
+            Assert.AreEqual(recordString, serialized);
+        }
+
+        class TestHasListThings
+        {
+            public List<Thing> TheThings { get; set; }
+        }
+
+        [Test]
+        public void TestSerializeSubObjectList()
+        {
+            string recordString = "TestHasListThings@TheThings:[(Value:17,Text:\"blah\"),(Value:18,Text:\"foo\")]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            TypeMapper<TestHasListThings> tm = TypeMapper<TestHasListThings>.Instance;
+            var t = new TestHasListThings();
+            tm.ToObject(document, t);
+
+            Assert.IsNotNull(t.TheThings);
+            Assert.AreEqual(2, t.TheThings.Count);
+            Assert.AreEqual(18, t.TheThings[1].Value);
+            Assert.AreEqual("foo", t.TheThings[1].Text);
+
+            ODocument newODocument = ODocument.ToDocument(t);
+            var serialized = Encoding.UTF8.GetString(serializer.Serialize(newODocument));
+            Assert.AreEqual(recordString, serialized);
+        }
+
+        [Test]
+        public void TestSerializeSingleSubObjectList()
+        {
+            string recordString = "TestHasListThings@TheThings:[(Value:18,Text:\"foo\")]";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            TypeMapper<TestHasListThings> tm = TypeMapper<TestHasListThings>.Instance;
+            var t = new TestHasListThings();
+            tm.ToObject(document, t);
+
+            Assert.IsNotNull(t.TheThings);
+            Assert.AreEqual(1, t.TheThings.Count);
+
+            ODocument newODocument = ODocument.ToDocument(t);
+            var serialized = Encoding.UTF8.GetString(serializer.Serialize(newODocument));
+            Assert.AreEqual(recordString, serialized);
+        }
+
+        class TestObject
+        {
+            public int Value { get; set; }
+            public string Text { get; set; }
+            public ORID Link { get; set; }
+            public List<ORID> single { get; set; }
+            public List<ORID> list { get; set; }
+
+            public ORID ORID { get; set; }
+            public byte[] data { get; set; }
+        }
+
+        [Test]
+        public void TestSerializationMapping()
+        {
+            // important if you use ordered edges, since if more than 1 they appear as a list, if only one then as a single object, ie
+            //    db.Create.Class<Person>().Extends("V").Run();
+            //    db.Command("create property Person.in_FriendOf ANY");
+            //    db.Command("alter property Person.in_FriendOf custom ordered=true");
+
+            string recordString = "TestObject@Value:17,Text:\"some text\",Link:#11:123,single:[#10:12345],list:[#11:123,#22:1234,#33:1234567],data:_AQIDBAU=_";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument()); 
+            
+            document.ORID = new ORID("#123:45");
+            Assert.AreEqual(document.HasField("single"), true);
+            Assert.AreEqual(document.HasField("Link"), true);
+            Assert.AreEqual(document.HasField("Value"), true);
+            Assert.AreEqual(document.HasField("Text"), true);
+            Assert.AreEqual(document.HasField("data"), true);
+
+
+            TypeMapper<TestObject> tm = TypeMapper<TestObject>.Instance;
+            var testObj = new TestObject();
+            tm.ToObject(document, testObj);
+
+            Assert.AreEqual("#123:45", testObj.ORID.RID);
+            Assert.IsTrue(testObj.data.SequenceEqual(new byte[] { 1, 2, 3, 4, 5 }));
+
+            Assert.AreEqual(17, testObj.Value);
+            Assert.AreEqual("some text", testObj.Text);
+            Assert.IsNotNull(testObj.Link);
+            Assert.AreEqual("#11:123", testObj.Link.RID);
+            Assert.IsNotNull(testObj);
+            Assert.IsNotNull(testObj.single);
+            Assert.IsNotNull(testObj.list);
+            Assert.AreEqual(1, testObj.single.Count);
+            Assert.AreEqual(3, testObj.list.Count);
+
+            ODocument newODocument = ODocument.ToDocument(testObj);
+            var serialized = Encoding.UTF8.GetString(serializer.Serialize(newODocument));
+            Assert.AreEqual(recordString, serialized);
+        }
+
+        [Test]
+        public void ShouldSerializeSingleAndSetOfOrids()
+        {
+            string recordString = "Something@single:#10:12345,set:<#11:123,#22:1234,#33:1234567>,singleSet:<#44:44>";
+
+            var rawRecord = Encoding.UTF8.GetBytes(recordString);
+            ODocument document = serializer.Deserialize(rawRecord, new ODocument());
+
+            // check for fields existence
+            Assert.AreEqual(document.HasField("single"), true);
+            Assert.AreEqual(document.HasField("set"), true);
+
+            // check for fields values
+            Assert.AreEqual(document.GetField<ORID>("single"), new ORID(10, 12345));
+            HashSet<ORID> collection = document.GetField<HashSet<ORID>>("set");
+            Assert.AreEqual(collection.Count, 3);
+            Assert.IsTrue(collection.Contains(new ORID(11, 123)));
+            Assert.IsTrue(collection.Contains(new ORID(22, 1234)));
+            Assert.IsTrue(collection.Contains(new ORID(33, 1234567)));
+
+            HashSet<ORID> singleSet = document.GetField<HashSet<ORID>>("singleSet");
+            Assert.AreEqual(singleSet.Count, 1);
+            Assert.IsTrue(singleSet.Contains(new ORID(44, 44)));
+
+            var serialized = Encoding.UTF8.GetString(serializer.Serialize(document));
+            Assert.AreEqual(recordString, serialized);
+        }
+
+
+    }
+}

--- a/src/Orient/Orient.NUnit/Serialization/RecordSerializationTests.cs
+++ b/src/Orient/Orient.NUnit/Serialization/RecordSerializationTests.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Orient.Client;
+using Orient.Client.API.Types;
+using Orient.Client.Protocol.Serializers;
+
+namespace Orient.Tests.Serialization
+{
+    [TestFixture]
+    public class RecordSerializationTests
+    {
+        private IRecordSerializer serializer;
+        [SetUp]
+        public void Init()
+        {
+            serializer = RecordSerializerFactory.GetSerializer(ORecordFormat.ORecordDocument2csv);
+        }
+        [Test]
+        public void ShouldNotSerializeFieldsWithAtCharacter()
+        {
+            string recordString = "TestClass@foo:true";
+
+            ODocument document = new ODocument()
+                .SetField("@OClassName", "TestClass")
+                .SetField("@ClassId", 123)
+                .SetField("@Foo", "bar")
+                .SetField("@ORID", new ORID(8, 0))
+                .SetField<bool>("foo", true);
+
+            string serializedRecord = Encoding.UTF8.GetString(serializer.Serialize(document));
+
+            Assert.AreEqual(serializedRecord, recordString);
+        }
+
+        [Test]
+        public void ShouldSerializeNull()
+        {
+            string recordString = "TestClass@null:,embedded:(null:)";
+
+            ODocument document = new ODocument()
+                .SetField("@OClassName", "TestClass")
+                .SetField<object>("null", null)
+                .SetField<object>("embedded.null", null);
+
+            string serializedRecord = Encoding.UTF8.GetString(serializer.Serialize(document));
+
+            Assert.AreEqual(serializedRecord, recordString);
+        }
+
+        [Test]
+        public void ShouldSerializeBoolean()
+        {
+            string recordString = "TestClass@isTrue:true,isFalse:false,embedded:(isTrue:true,isFalse:false),array:[true,false]";
+
+            ODocument document = new ODocument()
+                .SetField("@OClassName", "TestClass")
+                .SetField("isTrue", true)
+                .SetField("isFalse", false)
+                .SetField("embedded.isTrue", true)
+                .SetField("embedded.isFalse", false)
+                .SetField<List<bool>>("array", new List<bool> { true, false });
+
+            string serializedRecord = Encoding.UTF8.GetString(serializer.Serialize(document));
+
+            Assert.AreEqual(serializedRecord, recordString);
+        }
+
+        [Test]
+        public void ShouldSerializeNumbers()
+        {
+            string recordString = "TestClass@ByteNumber:123b,ShortNumber:1234s,IntNumber:123456,LongNumber:12345678901l,FloatNumber:3.14f,DoubleNumber:3.14d,DecimalNumber:1234567.8901c,embedded:(ByteNumber:123b,ShortNumber:1234s,IntNumber:123456,LongNumber:12345678901l,FloatNumber:3.14f,DoubleNumber:3.14d,DecimalNumber:1234567.8901c)";
+
+            ODocument document = new ODocument()
+                .SetField("@OClassName", "TestClass")
+                .SetField("ByteNumber", byte.Parse("123"))
+                .SetField("ShortNumber", short.Parse("1234"))
+                .SetField("IntNumber", 123456)
+                .SetField("LongNumber", 12345678901)
+                .SetField("FloatNumber", 3.14f)
+                .SetField("DoubleNumber", 3.14)
+                .SetField("DecimalNumber", new Decimal(1234567.8901))
+                .SetField("embedded.ByteNumber", byte.Parse("123"))
+                .SetField("embedded.ShortNumber", short.Parse("1234"))
+                .SetField("embedded.IntNumber", 123456)
+                .SetField("embedded.LongNumber", 12345678901)
+                .SetField("embedded.FloatNumber", 3.14f)
+                .SetField("embedded.DoubleNumber", 3.14)
+                .SetField("embedded.DecimalNumber", new Decimal(1234567.8901));
+
+            string serializedRecord = Encoding.UTF8.GetString(serializer.Serialize(document));
+
+            Assert.AreEqual(serializedRecord, recordString);
+        }
+
+        [Test]
+        public void ShouldSerializeDateTime()
+        {
+            DateTime dateTime = DateTime.Now;
+
+            // get Unix time version
+            DateTime unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            string timeString = ((long)((DateTime)dateTime - unixEpoch).TotalMilliseconds).ToString();
+
+            string recordString = "TestClass@DateTime:" + timeString + "t,embedded:(DateTime:" + timeString + "t)";
+
+            ODocument document = new ODocument()
+                .SetField("@OClassName", "TestClass")
+                .SetField("DateTime", dateTime)
+                .SetField("embedded.DateTime", dateTime);
+
+            string serializedRecord = Encoding.UTF8.GetString(serializer.Serialize(document));
+
+            Assert.AreEqual(serializedRecord, recordString);
+        }
+
+        [Test]
+        public void ShouldSerializeStrings()
+        {
+            string recordString = "TestClass@String:\"Bra\\" + "\"vo \\\\ asdf\",Array:[\"foo\",\"bar\"],embedded:(String:\"Bra\\" + "\"vo \\\\ asdf\",Array:[\"foo\",\"bar\"])";
+
+            ODocument document = new ODocument()
+                .SetField("@OClassName", "TestClass")
+                .SetField("String", "Bra\"vo \\ asdf")
+                .SetField("Array", new List<string> { "foo", "bar" })
+                .SetField("embedded.String", "Bra\"vo \\ asdf")
+                .SetField("embedded.Array", new List<string> { "foo", "bar" });
+
+
+            string serializedString = Encoding.UTF8.GetString(serializer.Serialize(document));
+
+            Assert.AreEqual(serializedString, recordString);
+        }
+
+        [Test]
+        public void ShouldSerializeORIDs()
+        {
+            string recordString = "TestClass@Single:#8:0,Array:[#8:1,#8:2],embedded:(Single:#9:0,Array:[#9:1,#9:2])";
+
+            ODocument document = new ODocument()
+                .SetField("@OClassName", "TestClass")
+                .SetField("Single", new ORID(8, 0))
+                .SetField("Array", new List<ORID> { new ORID(8, 1), new ORID(8, 2) })
+                .SetField("embedded.Single", new ORID(9, 0))
+                .SetField("embedded.Array", new List<ORID> { new ORID(9, 1), new ORID(9, 2) });
+
+            string serializedString = Encoding.UTF8.GetString(serializer.Serialize(document));
+
+            Assert.AreEqual(serializedString, recordString);
+        }
+
+        [Test]
+        public void ShouldSerializeListOfORIDs()
+        {
+            string recordString = "TestClass@Single:#8:0,Array:[#8:1,#8:2],embedded:(Array:[#9:1,#9:2])";
+
+            ODocument document = new ODocument()
+                .SetField("@OClassName", "TestClass")
+                .SetField("Single", new ORID(8, 0))
+                .SetField("Array", new List<ORID> { new ORID(8, 1), new ORID(8, 2) })
+                .SetField("embedded.Array", new List<ORID> { new ORID(9, 1), new ORID(9, 2) });
+
+            string serializedString = Encoding.UTF8.GetString(serializer.Serialize(document));
+
+            Assert.AreEqual(serializedString, recordString);
+        }
+
+        [Test]
+        public void ShouldSerializeByteArray()
+        {
+            string recordString = "TestClass@data:_AQIDBAU=_";
+
+            ODocument document = new ODocument()
+                .SetField("@OClassName", "TestClass")
+                .SetField("data", new byte[] {1, 2, 3, 4, 5});
+
+            string serializedString = Encoding.UTF8.GetString(serializer.Serialize(document));
+
+            Assert.AreEqual(serializedString, recordString);
+
+            var deserialized = serializer.Deserialize(Encoding.UTF8.GetBytes(serializedString), new ODocument());
+            byte[] data = deserialized.GetField<byte[]>("data");
+            Assert.IsTrue(data.SequenceEqual(new byte[] { 1, 2, 3, 4, 5 }));
+        }
+
+        [Test]
+        public void ShouldSerializeSetOfORIDs()
+        {
+            string recordString = "TestClass@Single:#8:0,Set:<#8:1,#8:2>,embedded:(Set:<#9:1,#9:2>)";
+
+            ODocument document = new ODocument()
+                .SetField("@OClassName", "TestClass")
+                .SetField("Single", new ORID(8, 0))
+                .SetField("Set", new HashSet<ORID> { new ORID(8, 1), new ORID(8, 2) })
+                .SetField("embedded.Set", new HashSet<ORID> { new ORID(9, 1), new ORID(9, 2) });
+
+            string serializedString = Encoding.UTF8.GetString(serializer.Serialize(document));
+
+            Assert.AreEqual(serializedString, recordString);
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Server/ServerOperationsTests.cs
+++ b/src/Orient/Orient.NUnit/Server/ServerOperationsTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Orient.Client;
+using Orient.Client.API.Types;
+using Orient.Client.Protocol.Serializers;
+
+namespace Orient.Tests.Server
+{
+    [TestFixture]
+    public class ServerOperationsTests
+    {
+        [Test]
+        public void ShouldCreateAndDeleteDatabase()
+        {
+            string databaseName = "thisIsTestDatabaseForNetDriver";
+            OServer server = TestConnection.GetServer();
+
+            bool exists = server.DatabaseExist(databaseName, OStorageType.PLocal);
+
+            if (exists)
+            {
+                server.DropDatabase(databaseName, OStorageType.PLocal);
+
+                exists = server.DatabaseExist(databaseName, OStorageType.PLocal);
+            }
+
+            Assert.AreEqual(exists, false);
+
+            if (!exists)
+            {
+                bool isCreated = server.CreateDatabase(databaseName, ODatabaseType.Graph, OStorageType.PLocal);
+
+                Assert.AreEqual(isCreated, true);
+
+                if (isCreated)
+                {
+                    server.DropDatabase(databaseName, OStorageType.PLocal);
+
+                    exists = server.DatabaseExist(databaseName, OStorageType.PLocal);
+
+                    Assert.AreEqual(exists, false);
+                }
+            }
+        }
+
+        [Test]
+        public void TestDbList()
+        {
+            using (var context = new TestDatabaseContext())
+            using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                OServer server = TestConnection.GetServer();
+                Dictionary<string, string> databases = server.Databases();
+                Assert.IsTrue(databases.Count > 0);
+            }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/TestConfigurationOperation.cs
+++ b/src/Orient/Orient.NUnit/TestConfigurationOperation.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests
+{
+    [TestFixture]
+    public class TestConfigurationOperation
+    {
+        [Test]
+        public void TestConfigGet()
+        {
+            OServer server = TestConnection.GetServer();
+            bool IsCreated = server.ConfigSet("network.retry", "6");
+            string value = server.ConfigGet("network.retry");
+            Assert.AreEqual("6", value);
+        }
+        [Test]
+        public void TestConfigList()
+        {
+            OServer server = TestConnection.GetServer();
+            Dictionary<string, string> config = server.ConfigList();
+            Assert.IsTrue(config.Count > 0);
+        }
+        [Test]
+        public void TestConfigSet()
+        {
+            OServer server = TestConnection.GetServer();
+            // Only Set existing keys
+            // Don't create new one
+            bool IsCreated = server.ConfigSet("network.retry", "6");
+            string loadedValue = server.ConfigGet("network.retry");
+            Assert.IsTrue(IsCreated);
+            Assert.AreEqual("6", loadedValue);
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/TestConnection.cs
+++ b/src/Orient/Orient.NUnit/TestConnection.cs
@@ -1,0 +1,69 @@
+﻿using Orient.Client;
+
+namespace Orient.Tests
+{
+    public static class TestConnection
+    {
+        private static string _hostname = "127.0.0.1";
+        private static int _port = 2424;
+        private static string _username = "admin";
+        private static string _password = "admin";
+
+        private static string _rootUserName = "root";
+        private static string _rootUserParssword = "root";
+        private static OServer _server;
+
+        public static int GlobalTestDatabasePoolSize { get { return 3; } }
+        public static string GlobalTestDatabaseName { get; private set; }
+        public static ODatabaseType GlobalTestDatabaseType { get; private set; }
+        public static string GlobalTestDatabaseAlias { get; private set; }
+
+        static TestConnection()
+        {
+            _server = new OServer(_hostname, _port, _rootUserName, _rootUserParssword);
+
+            GlobalTestDatabaseName = "globalTestDatabaseForNetDriver001";
+            GlobalTestDatabaseType = ODatabaseType.Graph;
+            GlobalTestDatabaseAlias = "globalTestDatabaseForNetDriver001Alias";
+        }
+
+        public static void CreateTestDatabase()
+        {
+            DropTestDatabase();
+
+            _server.CreateDatabase(GlobalTestDatabaseName, GlobalTestDatabaseType, OStorageType.Memory);
+        }
+
+        public static void DropTestDatabase()
+        {
+            if (_server.DatabaseExist(GlobalTestDatabaseName, OStorageType.Memory))
+            {
+                _server.DropDatabase(GlobalTestDatabaseName, OStorageType.Memory);
+            }
+        }
+
+        public static void CreateTestPool()
+        {
+            OClient.CreateDatabasePool(
+                _hostname,
+                _port,
+                GlobalTestDatabaseName,
+                GlobalTestDatabaseType,
+                _username,
+                _password,
+                GlobalTestDatabasePoolSize,
+                GlobalTestDatabaseAlias
+            );
+        }
+
+        public static void DropTestPool()
+        {
+            OClient.DropDatabasePool(GlobalTestDatabaseAlias);
+        }
+
+        public static OServer GetServer()
+        {
+            return _server;
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/TestDatabaseContext.cs
+++ b/src/Orient/Orient.NUnit/TestDatabaseContext.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Orient.Tests
+{
+    public class TestDatabaseContext : IDisposable
+    {
+        public TestDatabaseContext()
+        {
+            TestConnection.CreateTestDatabase();
+            TestConnection.CreateTestPool();
+        }
+
+        public void Dispose()
+        {
+            TestConnection.DropTestPool();
+            TestConnection.DropTestDatabase();
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/TestEdgeClass.cs
+++ b/src/Orient/Orient.NUnit/TestEdgeClass.cs
@@ -1,0 +1,16 @@
+﻿using Orient.Client;
+
+namespace Orient.Tests
+{
+    public class TestEdgeClass
+    {
+        [OProperty(Alias = "in", Serializable = false)]
+        public ORID In { get; set; }
+
+        [OProperty(Alias = "out", Serializable = false)]
+        public ORID Out { get; set; }
+
+        public string Foo { get; set; }
+        public int Bar { get; set; }
+    }
+}

--- a/src/Orient/Orient.NUnit/TestProfileClass.cs
+++ b/src/Orient/Orient.NUnit/TestProfileClass.cs
@@ -1,0 +1,10 @@
+﻿using Orient.Client;
+
+namespace Orient.Tests
+{
+    public class TestProfileClass : OBaseRecord
+    {
+        public string Name { get; set; }
+        public string Surname { get; set; }
+    }
+}

--- a/src/Orient/Orient.NUnit/TestVertexClass.cs
+++ b/src/Orient/Orient.NUnit/TestVertexClass.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orient.Tests
+{
+    public class TestVertexClass
+    {
+        public string Foo { get; set; }
+        public int Bar { get; set; }
+    }
+
+    public class TestVertexClass2
+    {
+        public string Foo { get; set; }
+        public int Bar { get; set; }
+    }
+}

--- a/src/Orient/Orient.NUnit/packages.config
+++ b/src/Orient/Orient.NUnit/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+</packages>

--- a/src/Orient/Orient.sln
+++ b/src/Orient/Orient.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Orient.Console", "Orient.Co
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Orient.Tests", "Orient.Tests\Orient.Tests.csproj", "{487B3635-ED01-4AD1-B90A-DA1E4358B580}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Orient.NUnit", "Orient.NUnit\Orient.NUnit.csproj", "{E9B69064-04DA-4554-A69F-A209106B525C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,14 +19,18 @@ Global
 		{224DB9BA-3BA5-4955-B147-E540E1F270DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{224DB9BA-3BA5-4955-B147-E540E1F270DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{224DB9BA-3BA5-4955-B147-E540E1F270DA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D290BB2C-98DC-4F83-8B3C-E9B2C9C41A50}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D290BB2C-98DC-4F83-8B3C-E9B2C9C41A50}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D290BB2C-98DC-4F83-8B3C-E9B2C9C41A50}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D290BB2C-98DC-4F83-8B3C-E9B2C9C41A50}.Release|Any CPU.Build.0 = Release|Any CPU
 		{487B3635-ED01-4AD1-B90A-DA1E4358B580}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{487B3635-ED01-4AD1-B90A-DA1E4358B580}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{487B3635-ED01-4AD1-B90A-DA1E4358B580}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{487B3635-ED01-4AD1-B90A-DA1E4358B580}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D290BB2C-98DC-4F83-8B3C-E9B2C9C41A50}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D290BB2C-98DC-4F83-8B3C-E9B2C9C41A50}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D290BB2C-98DC-4F83-8B3C-E9B2C9C41A50}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D290BB2C-98DC-4F83-8B3C-E9B2C9C41A50}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E9B69064-04DA-4554-A69F-A209106B525C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E9B69064-04DA-4554-A69F-A209106B525C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E9B69064-04DA-4554-A69F-A209106B525C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E9B69064-04DA-4554-A69F-A209106B525C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Orient/Orient.userprefs
+++ b/src/Orient/Orient.userprefs
@@ -1,0 +1,14 @@
+﻿<Properties StartupItem="Orient.NUnit/Orient.NUnit.csproj">
+  <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug" />
+  <MonoDevelop.Ide.Workbench ActiveDocument="Orient.NUnit/AssemblySetup.cs">
+    <Files>
+      <File FileName="Orient.NUnit/ClusterEqutableTest.cs" Line="7" Column="7" />
+      <File FileName="Orient.NUnit/DbRunner.cs" Line="36" Column="36" />
+      <File FileName="Orient.NUnit/AssemblySetup.cs" Line="8" Column="8" />
+    </Files>
+  </MonoDevelop.Ide.Workbench>
+  <MonoDevelop.Ide.DebuggingService.Breakpoints>
+    <BreakpointStore />
+  </MonoDevelop.Ide.DebuggingService.Breakpoints>
+  <MonoDevelop.Ide.DebuggingService.PinnedWatches />
+</Properties>


### PR DESCRIPTION
I would like to contribute to this project but my development environment is OS X + Xamarin Studio. Therefore I am unable to execute the MSTest project. In this pull request, I've created an NUnit project which should be functionally equivalent. The MSTest project has been left alone and the files were copied for the NUnit project. Only the using statements and class attributes where changed except for a little bit of unused code was removed in DbRunner.cs.

It is probably too much maintenance to maintain duplicate test suits in this project. I would like for you to please consider replacing the MSTest project with the NUnit project. If that isn't acceptable, I should be able to manage by locally maintaining my own version of the tests.

