### PR TITLE
test fixed for issue #28 and related to issue #31

### DIFF
--- a/src/Orient/Orient.Client/Protocol/Serializers/RecordCSVSerializer.cs
+++ b/src/Orient/Orient.Client/Protocol/Serializers/RecordCSVSerializer.cs
@@ -519,6 +519,8 @@ namespace Orient.Client.Protocol.Serializers
                 else if ((stringValue.Length > 2) && (stringValue[stringValue.Length - 1] == 't') || (stringValue[stringValue.Length - 1] == 'a'))
                 {
                     // Unix timestamp is miliseconds past epoch
+                    // FIXME: this assumes the server JVM timezone is UTC when it might not be
+                    // instead the timezone should be read from the server
                     DateTime epoch = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
                     string foo = stringValue.Substring(0, stringValue.Length - 1);
                     double d = double.Parse(foo);


### PR DESCRIPTION
While this doesn't fix the issue, it does demonstrate a workaround for getting consistent DateTime.

The deserialization of DateTime assumes the server is returning
UTC when database is using JVM default timezone which may be
a local timezone. This should be made more explicit. For now,
this updated test case demonstrates how to get it to work, by
setting the database timezone with "ALTER DATABASE TIMEZONE UTC"