### PR TITLE
Create class with custom name other than the type name

### DIFF
--- a/src/Orient/Orient.Client/API/Query/OSqlCreate.cs
+++ b/src/Orient/Orient.Client/API/Query/OSqlCreate.cs
@@ -30,6 +30,11 @@ namespace Orient.Client
             return new OSqlCreateClass(_connection).Class<T>();
         }
 
+        public OSqlCreateClass Class<T>(string className)
+        {
+            return new OSqlCreateClass(_connection).Class<T>(className);
+        }
+
         #endregion
 
         #region Cluster

--- a/src/Orient/Orient.Client/API/Query/OSqlCreateClass.cs
+++ b/src/Orient/Orient.Client/API/Query/OSqlCreateClass.cs
@@ -48,6 +48,13 @@ namespace Orient.Client
             return Class(_className);
         }
 
+        public OSqlCreateClass Class<T>(string className)
+        {
+            _type = typeof(T);
+            _className = className;
+            return Class(_className);
+        }
+
         #endregion
 
         #region Extends

--- a/src/Orient/Orient.NUnit/Query/SqlCreateClassTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlCreateClassTests.cs
@@ -121,5 +121,21 @@ namespace Orient.Tests.Query
                 }
             }
         }
+
+        [Test]
+        public void ShouldCreateClassWithCustomNameProperties()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            {
+                using (ODatabase database = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+                {
+                    short classId1 = database.Create.Class<TestClass>("MyTestClass").CreateProperties().Run();
+
+                    Assert.IsTrue(classId1 > 0);
+
+                    
+                }
+            }
+        }
     }
 }

--- a/src/Orient/Orient.NUnit/TestConnection.cs
+++ b/src/Orient/Orient.NUnit/TestConnection.cs
@@ -21,7 +21,7 @@ namespace Orient.Tests
         static TestConnection()
         {
             _server = new OServer(_hostname, _port, _rootUserName, _rootUserParssword);
-            //testing
+
             GlobalTestDatabaseName = "globalTestDatabaseForNetDriver001";
             GlobalTestDatabaseType = ODatabaseType.Graph;
             GlobalTestDatabaseAlias = "globalTestDatabaseForNetDriver001Alias";

--- a/src/Orient/Orient.NUnit/TestConnection.cs
+++ b/src/Orient/Orient.NUnit/TestConnection.cs
@@ -21,7 +21,7 @@ namespace Orient.Tests
         static TestConnection()
         {
             _server = new OServer(_hostname, _port, _rootUserName, _rootUserParssword);
-
+            //testing
             GlobalTestDatabaseName = "globalTestDatabaseForNetDriver001";
             GlobalTestDatabaseType = ODatabaseType.Graph;
             GlobalTestDatabaseAlias = "globalTestDatabaseForNetDriver001Alias";


### PR DESCRIPTION
Instead of Create.Class<TestClass>() which create the class name automatically, I have implemented a method to allow custom the class name Create.Class<TestClass>("MyTestClass") 