### PR TITLE
Various additions

### DIFF
--- a/src/Orient/Orient.Client/API/OClient.cs
+++ b/src/Orient/Orient.Client/API/OClient.cs
@@ -36,7 +36,7 @@ namespace Orient.Client
             _databasePools = new List<DatabasePool>();
             BufferLenght = 1024;
             Serializer = ORecordFormat.ORecordDocument2csv;
-            ClientID = null;
+            ClientID = "null";
             /* 
               If you enable token based session make shure enable it in server config
               <!-- USE SESSION TOKEN, TO TURN ON SET THE 'ENABLED' PARAMETER TO 'true' -->
@@ -55,7 +55,7 @@ namespace Orient.Client
             UseTokenBasedSession = false;
         }
 
-        public static string CreateDatabasePool(string hostname, int port, string databaseName, ODatabaseType databaseType, string userName, string userPassword, int poolSize, string alias, string clientID = null)
+        public static string CreateDatabasePool(string hostname, int port, string databaseName, ODatabaseType databaseType, string userName, string userPassword, int poolSize, string alias, string clientID = "null")
         {
             OClient.ClientID = clientID;
 

--- a/src/Orient/Orient.Client/API/OClient.cs
+++ b/src/Orient/Orient.Client/API/OClient.cs
@@ -9,7 +9,7 @@ namespace Orient.Client
     {
         private static object _syncRoot;
         private static List<DatabasePool> _databasePools;
-        internal static string ClientID { get { return "null"; } }
+        internal static string ClientID { get; set; }
         private static short _protocolVersion = 21;
         public static string DriverName { get { return "OrientDB-NET.binary"; } }
         public static string DriverVersion { get { return "0.2.1"; } }
@@ -36,6 +36,7 @@ namespace Orient.Client
             _databasePools = new List<DatabasePool>();
             BufferLenght = 1024;
             Serializer = ORecordFormat.ORecordDocument2csv;
+            ClientID = null;
             /* 
               If you enable token based session make shure enable it in server config
               <!-- USE SESSION TOKEN, TO TURN ON SET THE 'ENABLED' PARAMETER TO 'true' -->
@@ -54,8 +55,10 @@ namespace Orient.Client
             UseTokenBasedSession = false;
         }
 
-        public static string CreateDatabasePool(string hostname, int port, string databaseName, ODatabaseType databaseType, string userName, string userPassword, int poolSize, string alias)
+        public static string CreateDatabasePool(string hostname, int port, string databaseName, ODatabaseType databaseType, string userName, string userPassword, int poolSize, string alias, string clientID = null)
         {
+            OClient.ClientID = clientID;
+
             lock (_syncRoot)
             {
                 DatabasePool databasePool = new DatabasePool(hostname, port, databaseName, databaseType, userName, userPassword, poolSize, alias);

--- a/src/Orient/Orient.Client/API/ODatabase.cs
+++ b/src/Orient/Orient.Client/API/ODatabase.cs
@@ -9,6 +9,7 @@ using Orient.Client.API.Query.Interfaces;
 using Orient.Client.Protocol;
 using Orient.Client.Protocol.Operations;
 using Orient.Client.Protocol.Operations.Command;
+using Orient.Client.Protocol.Serializers;
 
 namespace Orient.Client
 {
@@ -187,13 +188,20 @@ namespace Orient.Client
             return convertedList;
         }
 
-        public List<ODocument> Query(string sql, string fetchPlan)
+        public List<ODocument> Query(string sql, string fetchPlan, Dictionary<string, object> parameters = null)
         {
             CommandPayloadQuery payload = new CommandPayloadQuery();
             payload.Text = sql;
             payload.NonTextLimit = -1;
             payload.FetchPlan = fetchPlan;
-            //payload.SerializedParams = new byte[] { 0 };
+
+            if (parameters != null)
+            {
+                ODocument paramsDoc = new ODocument();
+                paramsDoc.OClassName = "";
+                paramsDoc["params"] = parameters;
+                payload.SerializedParams = RecordSerializerFactory.GetSerializer(this).Serialize(paramsDoc);
+            }
 
             Command operation = new Command(_connection.Database);
             operation.OperationMode = OperationMode.Asynchronous;
@@ -212,6 +220,29 @@ namespace Orient.Client
 
         #endregion
 
+        public OCommandResult SqlBatch(string batch, Dictionary<string, object> parameters = null)
+        {
+            CommandPayloadScript payload = new CommandPayloadScript();
+            payload.Language = "sql";
+            payload.Text = batch;
+
+            if (parameters != null)
+            {
+                ODocument paramsDoc = new ODocument();
+                paramsDoc.OClassName = "";
+                paramsDoc["params"] = parameters;
+                payload.SimpleParams = RecordSerializerFactory.GetSerializer(this).Serialize(paramsDoc);
+            }
+
+            Command operation = new Command(this);
+            operation.OperationMode = OperationMode.Synchronous;
+            operation.CommandPayload = payload;
+
+            ODocument document = _connection.ExecuteOperation(operation);
+
+            return new OCommandResult(document);
+        }
+
         public OCommandResult Gremlin(string query)
         {
             CommandPayloadScript payload = new CommandPayloadScript();
@@ -226,6 +257,7 @@ namespace Orient.Client
 
             return new OCommandResult(document);
         }
+
         public OCommandQuery JavaScript(string query)
         {
             CommandPayloadScript payload = new CommandPayloadScript();
@@ -233,12 +265,20 @@ namespace Orient.Client
             payload.Text = query;
 
             return new OCommandQuery(_connection, payload);
-
         }
-        public OCommandResult Command(string sql)
+
+        public OCommandResult Command(string sql, Dictionary<string, object> parameters = null)
         {
             CommandPayloadCommand payload = new CommandPayloadCommand();
             payload.Text = sql;
+
+            if (parameters != null)
+            {
+                ODocument paramsDoc = new ODocument();
+                paramsDoc.OClassName = "";
+                paramsDoc["params"] = parameters;
+                payload.SimpleParams = RecordSerializerFactory.GetSerializer(this).Serialize(paramsDoc);
+            }
 
             Command operation = new Command(_connection.Database);
             operation.OperationMode = OperationMode.Synchronous;

--- a/src/Orient/Orient.Client/API/ODatabase.cs
+++ b/src/Orient/Orient.Client/API/ODatabase.cs
@@ -188,20 +188,12 @@ namespace Orient.Client
             return convertedList;
         }
 
-        public List<ODocument> Query(string sql, string fetchPlan, Dictionary<string, object> parameters = null)
+        public List<ODocument> Query(string sql, string fetchPlan)
         {
             CommandPayloadQuery payload = new CommandPayloadQuery();
             payload.Text = sql;
             payload.NonTextLimit = -1;
             payload.FetchPlan = fetchPlan;
-
-            if (parameters != null)
-            {
-                ODocument paramsDoc = new ODocument();
-                paramsDoc.OClassName = "";
-                paramsDoc["params"] = parameters;
-                payload.SerializedParams = RecordSerializerFactory.GetSerializer(this).Serialize(paramsDoc);
-            }
 
             Command operation = new Command(_connection.Database);
             operation.OperationMode = OperationMode.Asynchronous;
@@ -220,27 +212,13 @@ namespace Orient.Client
 
         #endregion
 
-        public OCommandResult SqlBatch(string batch, Dictionary<string, object> parameters = null)
+        public OCommandQuery SqlBatch(string batch)
         {
             CommandPayloadScript payload = new CommandPayloadScript();
             payload.Language = "sql";
             payload.Text = batch;
 
-            if (parameters != null)
-            {
-                ODocument paramsDoc = new ODocument();
-                paramsDoc.OClassName = "";
-                paramsDoc["params"] = parameters;
-                payload.SimpleParams = RecordSerializerFactory.GetSerializer(this).Serialize(paramsDoc);
-            }
-
-            Command operation = new Command(this);
-            operation.OperationMode = OperationMode.Synchronous;
-            operation.CommandPayload = payload;
-
-            ODocument document = _connection.ExecuteOperation(operation);
-
-            return new OCommandResult(document);
+            return new OCommandQuery(_connection, payload);
         }
 
         public OCommandResult Gremlin(string query)
@@ -267,26 +245,13 @@ namespace Orient.Client
             return new OCommandQuery(_connection, payload);
         }
 
-        public OCommandResult Command(string sql, Dictionary<string, object> parameters = null)
+        public OCommandResult Command(string sql)
         {
             CommandPayloadCommand payload = new CommandPayloadCommand();
             payload.Text = sql;
 
-            if (parameters != null)
-            {
-                ODocument paramsDoc = new ODocument();
-                paramsDoc.OClassName = "";
-                paramsDoc["params"] = parameters;
-                payload.SimpleParams = RecordSerializerFactory.GetSerializer(this).Serialize(paramsDoc);
-            }
-
-            Command operation = new Command(_connection.Database);
-            operation.OperationMode = OperationMode.Synchronous;
-            operation.CommandPayload = payload;
-
-            ODocument document = _connection.ExecuteOperation(operation);
-
-            return new OCommandResult(document);
+            OCommandQuery query = new OCommandQuery(_connection, payload);
+            return query.Run();
         }
 
         public PreparedCommand Command(PreparedCommand command)

--- a/src/Orient/Orient.Client/API/Query/OCommandQuery.cs
+++ b/src/Orient/Orient.Client/API/Query/OCommandQuery.cs
@@ -27,8 +27,7 @@ namespace Orient.Client.API.Query
             {
                 var paramsDocument = new ODocument();
                 paramsDocument.OClassName = "";
-                //paramsDocument.SetField<Dictionary<string, object>>("parameters", _simpleParams);
-                paramsDocument.SetField<Dictionary<string, object>>("params", _simpleParams);
+                paramsDocument.SetField(OClient.ProtocolVersion < 22 ? "params" : "parameters", _simpleParams);
                 ((CommandPayloadCommand)_payload).SimpleParams = RecordSerializerFactory.GetSerializer(_connection.Database).Serialize(paramsDocument);
             }
 

--- a/src/Orient/Orient.Client/API/Query/OCommandResult.cs
+++ b/src/Orient/Orient.Client/API/Query/OCommandResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Orient.Client.Protocol;
 
@@ -11,6 +12,21 @@ namespace Orient.Client
         internal OCommandResult(ODocument document)
         {
             _document = document;
+        }
+
+        public int GetModifiedCount()
+        {
+            switch (_document.GetField<PayloadStatus>("PayloadStatus"))
+            {
+                case PayloadStatus.SingleRecord:
+                    return 1;
+                case PayloadStatus.RecordCollection:
+                    return _document.GetField<List<ODocument>>("Content").Count;
+                case PayloadStatus.SerializedResult:
+                    return Convert.ToInt32(_document.GetField<object>("Content"));
+            }
+
+            return 0;
         }
 
         public ODocument ToSingle()

--- a/src/Orient/Orient.Client/API/Query/PreparedCommand.cs
+++ b/src/Orient/Orient.Client/API/Query/PreparedCommand.cs
@@ -45,7 +45,6 @@ namespace Orient.Client.API.Query
             }
 
             return RunInternal();
-
         }
 
         private OCommandResult RunInternal()
@@ -57,7 +56,7 @@ namespace Orient.Client.API.Query
 
                 var paramsDocument = new ODocument();
                 paramsDocument.OClassName = "";
-                paramsDocument.SetField("params", _parameters);
+                paramsDocument.SetField(OClient.ProtocolVersion < 22 ? "params" : "parameters", _parameters);
 
                 var serializer = RecordSerializerFactory.GetSerializer(_connection.Database);
 
@@ -78,8 +77,6 @@ namespace Orient.Client.API.Query
             {
                 _parameters = null;
             }
-
-
         }
 
         public OCommandResult Run()

--- a/src/Orient/Orient.Client/API/Query/PreparedCommand.cs
+++ b/src/Orient/Orient.Client/API/Query/PreparedCommand.cs
@@ -92,7 +92,7 @@ namespace Orient.Client.API.Query
             return _query;
         }
 
-        public PreparedCommand Set(string key, string value)
+        public PreparedCommand Set(string key, object value)
         {
             if (_parameters == null)
                 _parameters = new Dictionary<string, object>();

--- a/src/Orient/Orient.Client/API/Query/PreparedQuery.cs
+++ b/src/Orient/Orient.Client/API/Query/PreparedQuery.cs
@@ -96,7 +96,7 @@ namespace Orient.Client.API.Query
             return _query;
         }
 
-        public PreparedQuery Set(string key, string value)
+        public PreparedQuery Set(string key, object value)
         {
             if (_parameters == null)
                 _parameters = new Dictionary<string, object>();

--- a/src/Orient/Orient.Client/Protocol/Serializers/RecordCSVSerializer.cs
+++ b/src/Orient/Orient.Client/Protocol/Serializers/RecordCSVSerializer.cs
@@ -182,7 +182,21 @@ namespace Orient.Client.Protocol.Serializers
                             bld.Append(",");
 
                         first = false;
-                        bld.Append("\"" + keyVal.Key + "\":" + SerializeValue(keyVal.Value));
+
+                        //force serialized value as string in specific cases
+                        string serialized = SerializeValue(keyVal.Value);
+
+                        if (serialized.Length > 0)
+                        {
+                            char c = serialized[0];
+                            if (c == '.' || c == '#' || c == '<' || c == '[' || c == '(' || c == '{' || c == '0')
+                            {
+                                serialized = "\"" + serialized + "\"";
+                            }
+                        }
+
+
+                        bld.Append("\"" + keyVal.Key + "\":" + serialized);
                     }
 
                     bld.Append("}");

--- a/src/Orient/Orient.Client/Protocol/Serializers/RecordCSVSerializer.cs
+++ b/src/Orient/Orient.Client/Protocol/Serializers/RecordCSVSerializer.cs
@@ -664,8 +664,6 @@ namespace Orient.Client.Protocol.Serializers
                     if (_connection == null || !_connection.IsActive)
                         throw new OException(OExceptionType.Connection, "Connection is not opened or is null");
 
-                    List<ORID> ridbag = new List<ORID>();
-
                     // Tree based RidBag - (collectionPointer)(size:int)(changes)
 
                     // Collection Pointer - (fileId:long)(pageIndex:long)(pageOffset:int)
@@ -676,53 +674,57 @@ namespace Orient.Client.Protocol.Serializers
                     // size
                     var size = reader.ReadInt32EndianAware();
 
-                    // Changes - (changesSize:int)[(link:rid)(changeType:byte)(value:int)]*
-                    var changesSize = reader.ReadInt32EndianAware();
-                    for (int j = 0; j < changesSize; j++)
+                    //only process ridbag if size > 0, otherwise the call to SBTreeBonsaiFirstKey operation makes the connection crash (the server probably isn't expecting this use case)
+                    if (size > 0)
                     {
-                        throw new NotImplementedException("RidBag Changes not yet implemented");
-                    }
-
-                    var operation = new SBTreeBonsaiFirstKey(null);
-                    operation.FileId = fileId;
-                    operation.PageIndex = pageIndex;
-                    operation.PageOffset = pageOffset;
-
-
-                    // Not realy quiete about this
-                    var connection = OClient.ReleaseConnection(_connection.Alias);
-
-                    var entries = new Dictionary<ORID, int>();
-                    try
-                    {
-                        var orid = connection.ExecuteOperation(operation);
-                        var ft = true;
-                        var key = orid.GetField<ORID>("rid");
-                        do
+                        // Changes - (changesSize:int)[(link:rid)(changeType:byte)(value:int)]*
+                        var changesSize = reader.ReadInt32EndianAware();
+                        for (int j = 0; j < changesSize; j++)
                         {
-                            var op = new SBTreeBonsaiGetEntriesMajor(null);
-                            op.FileId = fileId;
-                            op.PageIndex = pageIndex;
-                            op.PageOffset = pageOffset;
-                            op.FirstKey = key;
-                            op.Inclusive = ft;
+                            throw new NotImplementedException("RidBag Changes not yet implemented");
+                        }
 
-                            var res = connection.ExecuteOperation(op);
-                            entries = res.GetField<Dictionary<ORID, int>>("entries");
+                        var operation = new SBTreeBonsaiFirstKey(null);
+                        operation.FileId = fileId;
+                        operation.PageIndex = pageIndex;
+                        operation.PageOffset = pageOffset;
 
-                            rids.AddRange(entries.Keys);
 
-                            if (entries.Count == 0)
-                                break;
+                        // Not realy quiete about this
+                        var connection = OClient.ReleaseConnection(_connection.Alias);
 
-                            key = entries.Last().Key;
-                            ft = false;
+                        var entries = new Dictionary<ORID, int>();
+                        try
+                        {
+                            var orid = connection.ExecuteOperation(operation);
+                            var ft = true;
+                            var key = orid.GetField<ORID>("rid");
+                            do
+                            {
+                                var op = new SBTreeBonsaiGetEntriesMajor(null);
+                                op.FileId = fileId;
+                                op.PageIndex = pageIndex;
+                                op.PageOffset = pageOffset;
+                                op.FirstKey = key;
+                                op.Inclusive = ft;
 
-                        } while (true);
-                    }
-                    finally
-                    {
-                        OClient.ReturnConnection(connection);
+                                var res = connection.ExecuteOperation(op);
+                                entries = res.GetField<Dictionary<ORID, int>>("entries");
+
+                                rids.AddRange(entries.Keys);
+
+                                if (entries.Count == 0)
+                                    break;
+
+                                key = entries.Last().Key;
+                                ft = false;
+
+                            } while (true);
+                        }
+                        finally
+                        {
+                            OClient.ReturnConnection(connection);
+                        }
                     }
                 }
             }

--- a/src/Orient/Orient.Client/Protocol/Serializers/RecordCSVSerializer.cs
+++ b/src/Orient/Orient.Client/Protocol/Serializers/RecordCSVSerializer.cs
@@ -183,19 +183,7 @@ namespace Orient.Client.Protocol.Serializers
 
                         first = false;
 
-                        //force serialized value as string in specific cases
                         string serialized = SerializeValue(keyVal.Value);
-
-                        if (serialized.Length > 0)
-                        {
-                            char c = serialized[0];
-                            if (c == '.' || c == '#' || c == '<' || c == '[' || c == '(' || c == '{' || c == '0')
-                            {
-                                serialized = "\"" + serialized + "\"";
-                            }
-                        }
-
-
                         bld.Append("\"" + keyVal.Key + "\":" + serialized);
                     }
 


### PR DESCRIPTION
I finally removed some of my implementations to keep in track with yours (no longer passing parameters as Dictionary). I also removed the double quoting I added as I couldn't reproduce issues in 1.7.8 and 2.0.11 regarding that. I also noticed that parameters don't work in 1.7.8 (protocol 21) in sqlbatch but they work when using 2.0.11 (protocol 28). This looks to be a bug in orientdb. However, in both versions they work for queries and commands but not for javascript. I also changed the parameters' values from type string to object. Not sure if there was a specific reason for only using strings? I ran the tests without issue.