### PR TITLE
Fix AppendORIDToField method for case when field does not exist

### DIFF
--- a/src/Orient/Orient.Client/API/OTransaction.cs
+++ b/src/Orient/Orient.Client/API/OTransaction.cs
@@ -113,7 +113,9 @@ namespace Orient.Client.API
         {
             if (document.HasField(field))
             {
-                document.GetField<HashSet<ORID>>(field).Add(orid);
+                var orids = document.GetField<HashSet<ORID>>(field);
+                orids.Add(orid);
+                document.SetField(field, orids);
             }
             else
             {


### PR DESCRIPTION
Since GetField() produces a new HashSet rather than the one attached to the document, SetField must be called in order to make this case work correctly.