### PR TITLE
Added ORecordBytes + transaction support

### DIFF
--- a/src/Orient/Orient.Client/API/Types/IBaseRecord.cs
+++ b/src/Orient/Orient.Client/API/Types/IBaseRecord.cs
@@ -6,5 +6,6 @@
         int OVersion { get; set; }
         short OClassId { get; set; }
         string OClassName { get; set; }
+        ORecordType ORecordType { get; set; }
     }
 }

--- a/src/Orient/Orient.Client/API/Types/IBaseRecord.cs
+++ b/src/Orient/Orient.Client/API/Types/IBaseRecord.cs
@@ -6,6 +6,6 @@
         int OVersion { get; set; }
         short OClassId { get; set; }
         string OClassName { get; set; }
-        ORecordType ORecordType { get; set; }
+        ORecordType OType { get; set; }
     }
 }

--- a/src/Orient/Orient.Client/API/Types/OBaseRecord.cs
+++ b/src/Orient/Orient.Client/API/Types/OBaseRecord.cs
@@ -14,6 +14,8 @@ namespace Orient.Client
 
         public short OClassId { get; set; }
 
+        public ORecordType ORecordType { get; set; }
+
         public string OClassName {
             get
             {

--- a/src/Orient/Orient.Client/API/Types/OBaseRecord.cs
+++ b/src/Orient/Orient.Client/API/Types/OBaseRecord.cs
@@ -14,7 +14,7 @@ namespace Orient.Client
 
         public short OClassId { get; set; }
 
-        public ORecordType ORecordType { get; set; }
+        public ORecordType OType { get; set; }
 
         public string OClassName {
             get

--- a/src/Orient/Orient.Client/API/Types/ODocument.cs
+++ b/src/Orient/Orient.Client/API/Types/ODocument.cs
@@ -4,7 +4,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Orient.Client.API.Types;
 using Orient.Client.Mapping;
 using Orient.Client.Protocol.Serializers;
 
@@ -61,7 +60,18 @@ namespace Orient.Client
             set { SetField("@OClassName", value); }
         }
 
+        public ORecordType ORecordType
+        {
+            get;
+            set;
+        }
+
         #endregion
+
+        public ODocument()
+        {
+            ORecordType = ORecordType.Document;
+        }
 
         public T GetField<T>(string fieldPath)
         {
@@ -161,7 +171,7 @@ namespace Orient.Client
                 else if (type == typeof(Decimal))
                 {
                     if (fieldValue != null)
-                        return (T)(object)Convert.ChangeType(fieldValue, typeof(T));
+                        return (T)(object)Convert.ChangeType(fieldValue, type);
                     else
                         return (T)(object)null;
                 }

--- a/src/Orient/Orient.Client/API/Types/ODocument.cs
+++ b/src/Orient/Orient.Client/API/Types/ODocument.cs
@@ -60,19 +60,8 @@ namespace Orient.Client
             set { SetField("@OClassName", value); }
         }
 
-        public ORecordType ORecordType
-        {
-            get;
-            set;
-        }
-
         #endregion
-
-        public ODocument()
-        {
-            ORecordType = ORecordType.Document;
-        }
-
+        
         public T GetField<T>(string fieldPath)
         {
             var type = typeof(T);

--- a/src/Orient/Orient.Client/API/Types/ORecordBytes.cs
+++ b/src/Orient/Orient.Client/API/Types/ORecordBytes.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Orient.Client
+{
+    /// <summary>
+    /// Raw record.
+    /// </summary>
+    public class ORecordBytes : IBaseRecord
+    {
+
+#region Properties which holds orient specific fields
+
+        public ORID ORID { get; set; }
+
+        public int OVersion { get; set; }
+
+        public short OClassId { get; set; }
+
+        public string OClassName { get; set; }
+
+        public ORecordType ORecordType
+        {
+            get { return ORecordType.RawBytes; }
+            set { }
+        }
+
+#endregion
+
+        public byte[] Content { get; set; }
+    }
+}

--- a/src/Orient/Orient.Client/API/Types/ORecordBytes.cs
+++ b/src/Orient/Orient.Client/API/Types/ORecordBytes.cs
@@ -21,7 +21,7 @@ namespace Orient.Client
 
         public string OClassName { get; set; }
 
-        public ORecordType ORecordType
+        public ORecordType OType
         {
             get { return ORecordType.RawBytes; }
             set { }

--- a/src/Orient/Orient.Client/Orient.Client.csproj
+++ b/src/Orient/Orient.Client/Orient.Client.csproj
@@ -30,6 +30,13 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>
+    </AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -67,6 +74,7 @@
     <Compile Include="API\Types\OBaseRecord.cs" />
     <Compile Include="API\Types\OEdge.cs" />
     <Compile Include="API\Types\OEmbeddedRidBag.cs" />
+    <Compile Include="API\Types\ORecordBytes.cs" />
     <Compile Include="API\Types\ORecordFormat.cs" />
     <Compile Include="API\Types\OToken.cs" />
     <Compile Include="API\Types\OVertex.cs" />
@@ -179,7 +187,6 @@
     <Compile Include="Transactions\ORIDSimplePropertyUpdater.cs" />
     <Compile Include="Transactions\ORIDUpdater.cs" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Orient/Orient.Client/Protocol/Operations/TransactionRecord.cs
+++ b/src/Orient/Orient.Client/Protocol/Operations/TransactionRecord.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Orient.Client.API.Types;
 using Orient.Client.Protocol.Serializers;
 
 namespace Orient.Client.Protocol.Operations

--- a/src/Orient/Orient.Client/Protocol/Operations/TransactionRecord.cs
+++ b/src/Orient/Orient.Client/Protocol/Operations/TransactionRecord.cs
@@ -70,14 +70,14 @@ namespace Orient.Client.Protocol.Operations
             }
         }
 
-        public ORecordType ORecordType
+        public ORecordType OType
         {
             get
             {
                 if (Document != null)
-                    return Document.ORecordType;
+                    return Document.OType;
 
-                return Object.ORecordType;
+                return Object.OType;
             }
         }
 
@@ -88,7 +88,7 @@ namespace Orient.Client.Protocol.Operations
             request.AddDataItem((byte)RecordType);
             request.AddDataItem(ORID.ClusterId);
             request.AddDataItem(ORID.ClusterPosition);
-            request.AddDataItem((byte)ORecordType);
+            request.AddDataItem((byte)OType);
 
             byte[] serializedDocument = null;
 


### PR DESCRIPTION
Hi,

I created an ORecordBytes class like in the native java driver to allow to insert/update raw records. I added support in the TransactionRecord class so we can add a document with link to raw record like that:
````
byte[] data = File.ReadAllBytes(<path to file>);

ORecordBytes record = new ORecordBytes();
record.Content = data;
database.Transaction.Add(record);

OVertex file= new OVertex();
file.SetField("rawdata", record.ORID);
fichier1.OClassName = "File";
database.Transaction.Add(file);

database.commit();
````

Next thing would be to have the LoadRecord operation return an ORecordBytes maybe instead of an ODocument with a RawBytes field when the ORecordType is RawBytes? Let me know what you think as this would probably incur breaking changes. Also the RecordCreate and RecordUpdate operations could allow the use of ORecordBytes (probably through the use of the IBaseRecord interface instead of forcing ODocument).

Finally, I left a comment TODO in the TransactionRecord suggesting that it could be better to let the IBaseRecord stream themselves so that relevant operations can just read their byte stream instead of checking what type its dealing with. Let me know what you think.