### PR TITLE
Added missing Upsert capability to OSqlUpdate.

### DIFF
--- a/src/Orient/Orient.Client/API/Query/OSqlUpdate.cs
+++ b/src/Orient/Orient.Client/API/Query/OSqlUpdate.cs
@@ -247,6 +247,17 @@ namespace Orient.Client
             return this;
         }
 
+        #region Upsert
+
+        public OSqlUpdate Upsert()
+        {
+            _sqlQuery.Upsert();
+
+            return this;
+        }
+
+        #endregion
+
         public int Run()
         {
             CommandPayloadCommand payload = new CommandPayloadCommand();

--- a/src/Orient/Orient.Client/Protocol/Query/Q.cs
+++ b/src/Orient/Orient.Client/Protocol/Query/Q.cs
@@ -46,6 +46,7 @@ namespace Orient.Client.Protocol
         internal static string Skip = "SKIP";
         internal static string To = "TO";
         internal static string Update = "UPDATE";
+        internal static string Upsert = "UPSERT";
         internal static string Values = "VALUES";
         internal static string Vertex = "VERTEX";
         internal static string Where = "WHERE";

--- a/src/Orient/Orient.Client/Protocol/Query/SqlQuery.cs
+++ b/src/Orient/Orient.Client/Protocol/Query/SqlQuery.cs
@@ -492,6 +492,15 @@ namespace Orient.Client.Protocol
 
         #endregion
 
+        #region Upsert
+
+        public void Upsert()
+        {
+            _compiler.Unique(Q.Upsert);
+        }
+
+        #endregion
+
         internal void OrderBy(params string[] fields)
         {
             for (int i = 0; i < fields.Length; i++)
@@ -798,6 +807,12 @@ namespace Orient.Client.Protocol
             else if (_compiler.HasKey(Q.Remove))
             {
                 query += string.Join(" ", "", Q.Remove, _compiler.Value(Q.Remove));
+            }
+
+            // (UPSERT)
+            if (_compiler.HasKey(Q.Upsert))
+            {
+                query += " " + Q.Upsert;
             }
 
             // [<conditions>](WHERE) 


### PR DESCRIPTION
I could not find anything about Upserts in the .NET binary so I created one myself.
If I haven't done anything wrong the whole diff is straight forward.
I just added another string to Q and two methods that add a unique field to query's compiler.
