### PR TITLE
Nested list and TimeSpan support

### DIFF
--- a/src/Orient/Orient.Client/API/Types/ODocument.cs
+++ b/src/Orient/Orient.Client/API/Types/ODocument.cs
@@ -151,6 +151,16 @@ namespace Orient.Client
                         return (T)(object)parsedValue;
                     }
                 }
+                else if (type == typeof(TimeSpan) || type == typeof(Nullable<TimeSpan>))
+                {
+                    if (fieldValue != null && (fieldValue.GetType() == typeof(TimeSpan) || fieldValue.GetType() == typeof(Nullable<TimeSpan>)))
+                        return (T)fieldValue;
+                    TimeSpan parsedValue;
+                    if (TimeSpan.TryParse((string)fieldValue, out parsedValue))
+                    {
+                        return (T)(object)parsedValue;
+                    }
+                }
                 else if (type == typeof(Guid))
                 {
                     Guid parsedValue;

--- a/src/Orient/Orient.Client/API/Types/TypeConverter.cs
+++ b/src/Orient/Orient.Client/API/Types/TypeConverter.cs
@@ -29,6 +29,8 @@ namespace Orient.Client.API.Types
             AddType<DateTime?>(OType.DateTime);
             AddType<byte?>(OType.Byte);
             AddType<decimal?>(OType.Decimal);
+            AddType<TimeSpan>(OType.String);
+            AddType<TimeSpan?>(OType.String);
             AddType<HashSet<ORID>>(OType.LinkSet);
             AddType<List<ORID>>(OType.LinkList);
             AddType<ORID>(OType.Link);

--- a/src/Orient/Orient.Client/API/Types/TypeConverter.cs
+++ b/src/Orient/Orient.Client/API/Types/TypeConverter.cs
@@ -20,6 +20,15 @@ namespace Orient.Client.API.Types
             AddType<byte[]>(OType.Binary);
             AddType<byte>(OType.Byte);
             AddType<decimal>(OType.Decimal);
+            AddType<int?>(OType.Integer);
+            AddType<long?>(OType.Long);
+            AddType<short?>(OType.Short);
+            AddType<bool?>(OType.Boolean);
+            AddType<float?>(OType.Float);
+            AddType<double?>(OType.Double);
+            AddType<DateTime?>(OType.DateTime);
+            AddType<byte?>(OType.Byte);
+            AddType<decimal?>(OType.Decimal);
             AddType<HashSet<ORID>>(OType.LinkSet);
             AddType<List<ORID>>(OType.LinkList);
             AddType<ORID>(OType.Link);
@@ -37,6 +46,17 @@ namespace Orient.Client.API.Types
             OType result;
             if (_types.TryGetValue(t, out result))
                 return result;
+
+            else if (t.FullName.Contains("System.Collections.Generic.HashSet"))
+                return OType.EmbeddedSet;
+
+            else if (typeof(System.Collections.IDictionary).IsAssignableFrom(t))
+                return OType.EmbeddedMap;
+
+            else if (typeof(System.Collections.IEnumerable).IsAssignableFrom(t))
+                return OType.EmbeddedList;
+            else if (!t.IsPrimitive)
+                return OType.Embedded;
 
             throw new ArgumentException("propertyType " + t.Name + " is not yet supported.");
         }

--- a/src/Orient/Orient.Client/Mapping/FastPropertyAccessor.cs
+++ b/src/Orient/Orient.Client/Mapping/FastPropertyAccessor.cs
@@ -41,7 +41,7 @@ namespace Orient.Client.Mapping
         public static Action<T, object> BuildUntypedSetter<T>(PropertyInfo propertyInfo)
         {
             var targetType = propertyInfo.DeclaringType;
-            var methodInfo = propertyInfo.GetSetMethod();
+            var methodInfo = propertyInfo.GetSetMethod(true);
             var exTarget = Expression.Parameter(targetType, "t");
             var exValue = Expression.Parameter(typeof(object), "p");
             var exBody = Expression.Call(exTarget, methodInfo, Expression.Convert(exValue, propertyInfo.PropertyType));
@@ -53,7 +53,7 @@ namespace Orient.Client.Mapping
         public static Func<T, object> BuildUntypedGetter<T>(PropertyInfo propertyInfo)
         {
             var targetType = propertyInfo.DeclaringType;
-            var methodInfo = propertyInfo.GetGetMethod();
+            var methodInfo = propertyInfo.GetGetMethod(true);
 
             var exTarget = Expression.Parameter(targetType, "t");
             var exBody = Expression.Call(exTarget, methodInfo);

--- a/src/Orient/Orient.Client/Mapping/NullableTimeSpanFieldMapping.cs
+++ b/src/Orient/Orient.Client/Mapping/NullableTimeSpanFieldMapping.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Orient.Client.Mapping
+{
+    internal class NullableTimeSpanFieldMapping<TTarget> : BasicNamedFieldMapping<TTarget>
+    {
+        public NullableTimeSpanFieldMapping(PropertyInfo propertyInfo, string fieldPath)
+            : base(propertyInfo, fieldPath)
+        {
+
+        }
+
+        protected override void MapToNamedField(ODocument document, TTarget typedObject)
+        {
+            Nullable<TimeSpan> timespan = document.GetField<Nullable<TimeSpan>>(_fieldPath);
+
+            SetPropertyValue(typedObject, timespan);
+        }
+    }
+}

--- a/src/Orient/Orient.Client/Mapping/TimeSpanFieldMapping.cs
+++ b/src/Orient/Orient.Client/Mapping/TimeSpanFieldMapping.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Orient.Client.Mapping
+{
+    internal class TimeSpanFieldMapping<TTarget> : BasicNamedFieldMapping<TTarget>
+    {
+        public TimeSpanFieldMapping(PropertyInfo propertyInfo, string fieldPath)
+            : base(propertyInfo, fieldPath)
+        {
+
+        }
+
+        protected override void MapToNamedField(ODocument document, TTarget typedObject)
+        {
+            TimeSpan timeSpan = document.GetField<TimeSpan>(_fieldPath);
+
+            SetPropertyValue(typedObject, timeSpan);
+        }
+    }
+}

--- a/src/Orient/Orient.Client/Mapping/TypeMapper.cs
+++ b/src/Orient/Orient.Client/Mapping/TypeMapper.cs
@@ -124,6 +124,14 @@ namespace Orient.Client.Mapping
                 {
                     _fields.Add(new DateTimeFieldMapping<T>(propertyInfo, fieldPath));
                 }
+                else if (propertyInfo.PropertyType == typeof(TimeSpan))
+                {
+                    _fields.Add(new TimeSpanFieldMapping<T>(propertyInfo, fieldPath));
+                }
+                else if (propertyInfo.PropertyType == typeof(Nullable<TimeSpan>))
+                {
+                    _fields.Add(new NullableTimeSpanFieldMapping<T>(propertyInfo, fieldPath));
+                }
                 else if (propertyInfo.PropertyType == typeof(long))
                 {
                     _fields.Add(new LongFieldMapping<T>(propertyInfo, fieldPath));

--- a/src/Orient/Orient.Client/Orient.Client.csproj
+++ b/src/Orient/Orient.Client/Orient.Client.csproj
@@ -110,8 +110,10 @@
     <Compile Include="Mapping\GuidFieldMapping.cs" />
     <Compile Include="Mapping\HashSetNamedFieldMapping.cs" />
     <Compile Include="Mapping\LongFieldMapping.cs" />
+    <Compile Include="Mapping\NullableTimeSpanFieldMapping.cs" />
     <Compile Include="Mapping\ORIDFieldMapping.cs" />
     <Compile Include="Mapping\ShortFieldMapping.cs" />
+    <Compile Include="Mapping\TimeSpanFieldMapping.cs" />
     <Compile Include="Mapping\TypeMapper.cs" />
     <Compile Include="Protocol\BinaryReaderHelper.cs" />
     <Compile Include="Protocol\Operations\BaseOperation.cs" />

--- a/src/Orient/Orient.Client/Protocol/Query/SqlQuery.cs
+++ b/src/Orient/Orient.Client/Protocol/Query/SqlQuery.cs
@@ -566,6 +566,10 @@ namespace Orient.Client.Protocol
                     sql = "'" + fieldValue.ToString(dateTimeFormat) + "'";
                 }
             }
+            else if (value is TimeSpan)
+            {
+                sql = "'" + value.ToString() + "'";
+            }
             else if (value is ODocument)
             {
                 var document = ((ODocument)value);

--- a/src/Orient/Orient.Client/Protocol/Query/SqlQuery.cs
+++ b/src/Orient/Orient.Client/Protocol/Query/SqlQuery.cs
@@ -276,12 +276,13 @@ namespace Orient.Client.Protocol
         {
             string field = "";
 
-            if (_compiler.HasKey(Q.Set))
+            if (_compiler.HasKey(Q.Set) && !string.IsNullOrWhiteSpace(fieldName))
             {
                 field += ", ";
             }
 
-            field += string.Join(" ", fieldName, Q.Equals, "");
+            if (!string.IsNullOrWhiteSpace(fieldName))
+                field += string.Join(" ", fieldName, Q.Equals, "");
 
             if (fieldValue == null)
             {
@@ -295,10 +296,7 @@ namespace Orient.Client.Protocol
 
                 foreach (object item in collection)
                 {
-                    if (item != null)
-                        field += ToString(item);
-                    else
-                        field += "null";
+                    field += BuildFieldValue(null, item);
 
                     iteration++;
 
@@ -322,7 +320,7 @@ namespace Orient.Client.Protocol
                     iteration++;
                     if (enumerator.Value != null)
                     {
-                        field += String.Format("'{0}':{1}", enumerator.Key, ToString(enumerator.Value));
+                        field += String.Format("'{0}':{1}", enumerator.Key, BuildFieldValue(null, enumerator.Value));
 
                         if (iteration < dict.Count)
                             field += ", ";
@@ -619,6 +617,10 @@ namespace Orient.Client.Protocol
             else if (value is double)
             {
                 sql = string.Join(" ", value.ToInvarianCultureString() + "d");
+            }
+            else if (value == null)
+            {
+                sql = string.Join(" ", "null");
             }
             else
             {

--- a/src/Orient/Orient.NUnit/Issues/GitHub_issue71.cs
+++ b/src/Orient/Orient.NUnit/Issues/GitHub_issue71.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Issues
+{
+    [TestFixture(Category = "issues")]
+    public class GitHub_issue71
+    {
+        private string _metadataQuery = "select expand(properties) from (select expand(classes) from #0:1) where name='TestClass'";
+
+        [Test]
+        public void ShouldCreateNonPrimitiveProperties()
+        {
+            using (TestDatabaseContext testContext = new TestDatabaseContext())
+            using (var db = new ODatabase(TestConnection.GlobalTestDatabaseAlias))
+            {
+                if (!db.Schema.IsClassExist<TestClass>())
+                {
+                    db.Create.Class<TestClass>().CreateProperties<TestClass>().Run();
+
+                    var document = db.Query(_metadataQuery);
+
+                    var SomeListMetadata = document.Find(d => d.GetField<string>("name") == "SomeList");
+                    validateMetadata(SomeListMetadata, OType.EmbeddedList);
+
+                    var DictionaryMetadata = document.Find(d => d.GetField<string>("name") == "Dictionary");
+                    validateMetadata(DictionaryMetadata, OType.EmbeddedMap);
+                }
+            }
+        }
+
+        private void validateMetadata(ODocument metadata, OType expectedType)
+        {
+            Assert.IsNotNull(metadata);
+            Assert.AreEqual(expectedType, (OType)metadata.GetField<int>("type"));
+        }
+        
+        public class TestClass
+        {
+            public TestClass()
+            {
+
+            }
+            public List<string> SomeList { get; set; }
+            public string SomeString { get; set; }
+            public int? NullableInt { get; set; }
+            public HashSet<string> Hashset { get; set; }
+            public Dictionary<string, string> Dictionary { get; set; }
+            public TestEmbeddedClass EmbeddedClass { get; set; }
+        }
+
+        public class TestEmbeddedClass
+        {
+            public string StringProperty { get; set; }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Issues/GitHub_issue88.cs
+++ b/src/Orient/Orient.NUnit/Issues/GitHub_issue88.cs
@@ -29,7 +29,7 @@ namespace Orient.Tests.Issues
         }
 
         [Test]
-        public void ShouldInsertObjectWithNestedObjectList()
+        public void ShouldInsertObjectWithNestedObject()
         {
             // prerequisites
             _database
@@ -42,15 +42,18 @@ namespace Orient.Tests.Issues
             profile.Dictionary = new Dictionary<string, string>();
             profile.Dictionary.Add("Key1", "Value1");
             profile.Dictionary.Add("Key2", "Value2");
-            profile.NestedObject = new TestNestedObject() { Strings = new List<string>() { "Address 1", "address 2" }, Dictionary = new Dictionary<string, string>() { { "Key1", "Value1" }, { "Key2", "Value2" } } };
+            profile.NestedObject = new TestNestedObject() { Strings = new List<string>() { "Address 1", "address 2" }, Test1 = "test", Test2 = null, Dictionary = new Dictionary<string, string>() { { "Key1", "Value1" }, { "Key2", "Value2" } }, ObjectHashSet = new HashSet<TestNestedObject2>() { new TestNestedObject2() { Test1 = "Test1", Test2 = 2 } } };
 
             TestProfileClassExtended profile2 = new TestProfileClassExtended();
             profile2.Name = "Richard";
             profile2.Surname = "Benson";
-            profile2.NestedObject = new TestNestedObject() { Strings = new List<string>() { "Address 3", "address 4" }, Dictionary = new Dictionary<string, string>() { { "Key3", "Value3" }, { "Key4", "Value4" } } };
+            profile2.NestedObject = new TestNestedObject() { Strings = new List<string>() { "Address 3", "address 4" }, Test1 = "test2", Test2 = 3, Dictionary = new Dictionary<string, string>() { { "Key3", "Value3" }, { "Key4", "Value4" } }, ObjectHashSet = new HashSet<TestNestedObject2>() { new TestNestedObject2() { Test1 = "Test1", Test2 = null } } };
             profile2.Dictionary = new Dictionary<string, string>();
             profile2.Dictionary.Add("Key3", "Value3");
             profile2.Dictionary.Add("Key4", "Value4");
+
+            TestProfileClassExtended profile3 = new TestProfileClassExtended();
+            profile3.NestedObject = new TestNestedObject();
 
             TestProfileClassExtended insertedDocument = _database
                 .Insert(profile)
@@ -58,6 +61,10 @@ namespace Orient.Tests.Issues
 
             TestProfileClassExtended insertedDocument2 = _database
                 .Insert(profile2)
+                .Run<TestProfileClassExtended>();
+
+            TestProfileClassExtended insertedDocument3 = _database
+                .Insert(profile3)
                 .Run<TestProfileClassExtended>();
 
             List<TestProfileClassExtended> documents = _database
@@ -69,8 +76,25 @@ namespace Orient.Tests.Issues
             Assert.IsNotNull(documents[0].NestedObject);
             Assert.IsNotNull(documents[0].NestedObject.Strings);
             Assert.Greater(documents[0].NestedObject.Strings.Count, 0);
+            Assert.IsNotNull(documents[0].NestedObject.Test1);
+            Assert.IsNull(documents[0].NestedObject.Test2);
             Assert.Greater(documents[0].NestedObject.Dictionary.Keys.Count, 0);
             Assert.Greater(documents[0].Dictionary.Keys.Count, 0);
+            Assert.Greater(documents[0].NestedObject.ObjectHashSet.Count, 0);
+            Assert.IsNotNull(documents[0].NestedObject.ObjectHashSet.First().Test1);
+            Assert.IsNotNull(documents[0].NestedObject.ObjectHashSet.First().Test2);
+
+            Assert.IsNotNull(documents[1].NestedObject);
+            Assert.IsNotNull(documents[1].NestedObject.Strings);
+            Assert.Greater(documents[1].NestedObject.Strings.Count, 0);
+            Assert.IsNotNull(documents[1].NestedObject.Test1);
+            Assert.IsNotNull(documents[1].NestedObject.Test2);
+            Assert.Greater(documents[1].NestedObject.Dictionary.Keys.Count, 0);
+            Assert.Greater(documents[1].Dictionary.Keys.Count, 0);
+            Assert.IsNotNull(documents[1].NestedObject.ObjectHashSet.First().Test1);
+            Assert.IsNull(documents[1].NestedObject.ObjectHashSet.First().Test2);
+
+            Assert.IsNotNull(documents[2].NestedObject);
         }
 
         public class TestProfileClassExtended : TestProfileClass
@@ -84,7 +108,20 @@ namespace Orient.Tests.Issues
         {
             public List<string> Strings { get; set; }
 
+            public HashSet<TestNestedObject2> ObjectHashSet { get; set; }
+
             public Dictionary<string, string> Dictionary { get; set; }
+
+            public string Test1 { get; set; }
+
+            public int? Test2 { get; set; }
+        }
+
+        public class TestNestedObject2
+        {
+            public string Test1 { get; set; }
+
+            public int? Test2 { get; set; }
         }
     }
 }

--- a/src/Orient/Orient.NUnit/Issues/GitHub_issue88.cs
+++ b/src/Orient/Orient.NUnit/Issues/GitHub_issue88.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Orient.Client;
+
+namespace Orient.Tests.Issues
+{
+    [TestFixture]
+    public class GitHub_issue88
+    {
+        TestDatabaseContext _context;
+        ODatabase _database;
+
+        [SetUp]
+        public void Init()
+        {
+            _context = new TestDatabaseContext();
+            _database = new ODatabase(TestConnection.GlobalTestDatabaseAlias);
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            _database.Dispose();
+            _context.Dispose();
+        }
+
+        [Test]
+        public void ShouldInsertObjectWithNestedObjectList()
+        {
+            // prerequisites
+            _database
+                .Create.Class<TestProfileClassExtended>()
+                .Run();
+
+            TestProfileClassExtended profile = new TestProfileClassExtended();
+            profile.Name = "Johny";
+            profile.Surname = "Bravo";
+            profile.Dictionary = new Dictionary<string, string>();
+            profile.Dictionary.Add("Key1", "Value1");
+            profile.Dictionary.Add("Key2", "Value2");
+            profile.NestedObject = new TestNestedObject() { Strings = new List<string>() { "Address 1", "address 2" }, Dictionary = new Dictionary<string, string>() { { "Key1", "Value1" }, { "Key2", "Value2" } } };
+
+            TestProfileClassExtended profile2 = new TestProfileClassExtended();
+            profile2.Name = "Richard";
+            profile2.Surname = "Benson";
+            profile2.NestedObject = new TestNestedObject() { Strings = new List<string>() { "Address 3", "address 4" }, Dictionary = new Dictionary<string, string>() { { "Key3", "Value3" }, { "Key4", "Value4" } } };
+            profile2.Dictionary = new Dictionary<string, string>();
+            profile2.Dictionary.Add("Key3", "Value3");
+            profile2.Dictionary.Add("Key4", "Value4");
+
+            TestProfileClassExtended insertedDocument = _database
+                .Insert(profile)
+                .Run<TestProfileClassExtended>();
+
+            TestProfileClassExtended insertedDocument2 = _database
+                .Insert(profile2)
+                .Run<TestProfileClassExtended>();
+
+            List<TestProfileClassExtended> documents = _database
+                .Select()
+                .From<TestProfileClassExtended>()
+                .ToList<TestProfileClassExtended>();
+
+            Assert.Greater(documents.Count, 0);
+            Assert.IsNotNull(documents[0].NestedObject);
+            Assert.IsNotNull(documents[0].NestedObject.Strings);
+            Assert.Greater(documents[0].NestedObject.Strings.Count, 0);
+            Assert.Greater(documents[0].NestedObject.Dictionary.Keys.Count, 0);
+            Assert.Greater(documents[0].Dictionary.Keys.Count, 0);
+        }
+
+        public class TestProfileClassExtended : TestProfileClass
+        {
+            public TestNestedObject NestedObject { get; set; }
+
+            public Dictionary<string, string> Dictionary { get; set; }
+        }
+
+        public class TestNestedObject
+        {
+            public List<string> Strings { get; set; }
+
+            public Dictionary<string, string> Dictionary { get; set; }
+        }
+    }
+}

--- a/src/Orient/Orient.NUnit/Orient.NUnit.csproj
+++ b/src/Orient/Orient.NUnit/Orient.NUnit.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Issues\GitHub_issue54.cs" />
     <Compile Include="Issues\GitHub_issue57.cs" />
     <Compile Include="Issues\GitHub_issue62.cs" />
+    <Compile Include="Issues\GitHub_issue88.cs" />
     <Compile Include="Issues\GitHub_issue86.cs" />
     <Compile Include="Issues\GitHub_issue85.cs" />
     <Compile Include="Issues\GitHub_issue84.cs" />

--- a/src/Orient/Orient.NUnit/Orient.NUnit.csproj
+++ b/src/Orient/Orient.NUnit/Orient.NUnit.csproj
@@ -45,6 +45,7 @@
     <Compile Include="AssemblySetup.cs" />
     <Compile Include="ClusterEqutableTest.cs" />
     <Compile Include="DbRunner.cs" />
+    <Compile Include="Issues\GitHub_issue71.cs" />
     <Compile Include="Issues\GitHub_issue55.cs" />
     <Compile Include="Issues\GitHub_issue23.cs" />
     <Compile Include="Issues\GitHub_issue38.cs" />

--- a/src/Orient/Orient.NUnit/Orient.NUnit.csproj
+++ b/src/Orient/Orient.NUnit/Orient.NUnit.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Issues\GitHub_issue83.cs" />
     <Compile Include="Issues\GitHub_issue8.cs" />
     <Compile Include="Query\PreparedQueryTest.cs" />
+    <Compile Include="Query\SqlTimespanFieldTests.cs" />
     <Compile Include="Serialization\RecordCSVSerializerTest.cs" />
     <Compile Include="TestConfigurationOperation.cs" />
     <Compile Include="TestConnection.cs" />

--- a/src/Orient/Orient.NUnit/Query/SqlTimespanFieldTests.cs
+++ b/src/Orient/Orient.NUnit/Query/SqlTimespanFieldTests.cs
@@ -1,0 +1,68 @@
+﻿using NUnit.Framework;
+using Orient.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orient.Tests.Query
+{
+    [TestFixture]
+    public class SqlTimespanFieldTests
+    {
+        TestDatabaseContext _context;
+        ODatabase _database;
+
+        [SetUp]
+        public void Init()
+        {
+            _context = new TestDatabaseContext();
+            _database = new ODatabase(TestConnection.GlobalTestDatabaseAlias);
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            _database.Dispose();
+            _context.Dispose();
+        }
+
+        [Test]
+        public void ShouldInsertTimespanValues()
+        {
+            // prerequisites
+            _database
+                .Create.Class<TestTimeSpanClass>()
+                .CreateProperties()
+                .Run();
+
+            TestTimeSpanClass testClass = new TestTimeSpanClass();
+
+            testClass.TimespanProp = TimeSpan.FromDays(1);
+            testClass.EmbeddedObj = new TestTimeSpanEmbeddedClass();
+            testClass.TimespanProp = TimeSpan.FromHours(2);
+
+            TestTimeSpanClass insertedDocument = _database
+                .Insert(testClass)
+                .Run<TestTimeSpanClass>();
+
+        }
+
+        public class TestTimeSpanClass
+        {
+            public TimeSpan TimespanProp { get; set; }
+
+            public TimeSpan? NullableTimespanProp { get; set; }
+
+            public TestTimeSpanEmbeddedClass EmbeddedObj { get; set; }
+        }
+
+        public class TestTimeSpanEmbeddedClass
+        {
+            public TimeSpan TimespanProp { get; set; }
+
+            public TimeSpan? NullableTimespanProp { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
I added support for nested properties of type IEnumerable<T> and IDictionary<T> (issue #88)  and support for TimeSpan fields. TimeSpan are serialized as string, as there's no native support in Java and other languages.
There are a fix for issue #71 and a fix for private get and set properties in FastPropertyAccessor.