### PR TITLE
Cast error on (T)fieldValue;

### DIFF
--- a/src/OrientDB-Net.binary.Innov8tive/API/Types/ODocument.cs
+++ b/src/OrientDB-Net.binary.Innov8tive/API/Types/ODocument.cs
@@ -71,7 +71,10 @@ namespace Orient.Client
 
             if (TryGetValue(fieldPath, out fieldValue))
             {
-                if (fieldValue == null || fieldValue.GetType() == typeof(T))
+                if (fieldValue == null)
+                    return default(T);
+
+                if (fieldValue.GetType() == typeof(T))
                     return (T)fieldValue;
 
                 if (fieldValue is ICollection && (fieldValue as ICollection).Count == 1)


### PR DESCRIPTION
when fieldValue is null it can't be cast to (T)fieldValue. 
default(T); should be used when fieldValue is null.

also, code swallows thrown exception.