### PR TITLE
removing _containsConnection in ODatabase which causes a connection to never get closed

### DIFF
--- a/src/OrientDB-Net.binary.Innov8tive/API/ODatabase.cs
+++ b/src/OrientDB-Net.binary.Innov8tive/API/ODatabase.cs
@@ -19,8 +19,6 @@ namespace Orient.Client
 {
     public class ODatabase : IDisposable
     {
-        private bool _containsConnection;
-
         private ODocument _databaseProperties;
 
         public IDictionary<ORID, ODocument> ClientCache { get; private set; }
@@ -306,14 +304,9 @@ namespace Orient.Client
 
         public void Close()
         {
-            if (_containsConnection)
-            {
-                GetConnection().Database = null;
+            GetConnection().Database = null;
 
-                GetConnection().Dispose();
-
-                _containsConnection = false;
-            }
+            GetConnection().Dispose();
         }
 
         public void Dispose()


### PR DESCRIPTION
In the `Close()` method of the `ODatabase` class it does a check for `_containsConnection`, but that instance variable is never set to true so the connection is never closed. Adding a fix to remove this check, as the `Close()` method in the `Connection` class does a check for active connections before it closes the connection.